### PR TITLE
Dokli as Code (f1): manifest models + live state

### DIFF
--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -3,9 +3,12 @@
 from typing import Any
 
 import typer
+import yaml
+from rich import print as rprint
 
-from dokli.config import Config
+from dokli.config import Config, ConnectionConfig
 from dokli.openapi_cli import register_connections
+from dokli.state import collect_state
 
 try:
     from dokli.tui import app as tui
@@ -30,6 +33,27 @@ def tui_command() -> None:
 
 if _tui_loaded:
     app.command(name="tui")(tui_command)
+
+
+def _get_connection(connection_name: str | None) -> ConnectionConfig:
+    """Resolve a connection by name, or the only configured one."""
+    config = state["config"]
+    if connection_name is not None:
+        for connection in config.connections:
+            if connection.name == connection_name:
+                return connection
+        raise typer.BadParameter(f"Unknown connection '{connection_name}'.")
+    if len(config.connections) == 1:
+        return config.connections[0]
+    raise typer.BadParameter("Specify a connection name.")
+
+
+@app.command(name="state")
+def state_command(connection_name: str | None = typer.Argument(None, help="Connection name.")) -> None:
+    """Show the current state of a Dokploy instance."""
+    connection = _get_connection(connection_name)
+    live_state = collect_state(connection)
+    rprint(yaml.dump(live_state.model_dump(mode="json")))
 
 
 @app.callback(no_args_is_help=True)

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -1,0 +1,112 @@
+"""Declarative manifest models for Dokli as Code.
+
+The manifest (``dokli.yaml``) describes the desired state of a Dokploy
+instance. See :issue:`20`.
+"""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
+class GitProvider(BaseModel):
+    """A git provider referenced by services.
+
+    Credentials are write-only in Dokploy's API, so they are never stored in
+    the manifest. Use ``token_cmd`` to resolve them externally at apply time,
+    mirroring ``ConnectionConfig.api_key_cmd``.
+    """
+
+    name: str
+    provider: Literal["github", "gitlab", "gitea", "bitbucket"]
+    url: str = Field(
+        default="https://github.com",
+        description="Provider URL. Needed for self-hosted gitea/gitlab or GitHub Enterprise.",
+    )
+    app_name: str | None = Field(default=None, description="GitHub App name (metadata only).")
+    owner: str | None = Field(default=None, description="Provider owner/account (metadata only).")
+    token_cmd: str | None = Field(
+        default=None,
+        description="Command that outputs the credential. Never store the value here.",
+    )
+
+
+class GitSource(BaseModel):
+    """A repository source backed by a git provider."""
+
+    provider: str = Field(..., description="Name of the git_providers entry.")
+    repository: str = Field(..., description="Repository path, e.g. owner/repo.")
+    branch: str = Field(default="main")
+
+
+class ComposeService(BaseModel):
+    """A compose service."""
+
+    type: Literal["compose"] = "compose"
+    name: str
+    description: str | None = None
+    source: GitSource | None = Field(
+        default=None,
+        description="Git repository source. Mutually exclusive with compose_file.",
+    )
+    compose_file: str | None = Field(
+        default=None,
+        description="Raw compose YAML or a path to a local file. Mutually exclusive with source.",
+    )
+    compose_path: str | None = Field(
+        default=None,
+        description="Path to the compose file inside the repository.",
+    )
+    command: str | None = None
+    env: str | None = Field(default=None, description="Environment variables as KEY=VALUE lines.")
+
+
+class ApplicationService(BaseModel):
+    """An application service."""
+
+    type: Literal["application"] = "application"
+    name: str
+    description: str | None = None
+    source: GitSource | None = Field(default=None, description="Git repository source.")
+    image: str | None = Field(default=None, description="Docker image for a docker source.")
+    build_type: str | None = Field(
+        default=None,
+        description="dockerfile, nixpacks, static, ...",
+    )
+    dockerfile_location: str | None = None
+    build_path: str | None = None
+    env: str | None = Field(default=None, description="Environment variables as KEY=VALUE lines.")
+
+
+Service = Annotated[ComposeService | ApplicationService, Field(discriminator="type")]
+
+
+class ProjectDef(BaseModel):
+    """A project with its services."""
+
+    name: str
+    description: str | None = None
+    services: list[Service] = Field(default_factory=list)
+
+
+class Manifest(BaseModel):
+    """Dokli as Code manifest."""
+
+    connection: str = Field(..., description="Connection name from dokli's config.")
+    server: str | None = Field(
+        default=None,
+        description="Server name to deploy to. Defaults to the local server.",
+    )
+    git_providers: list[GitProvider] = Field(default_factory=list)
+    projects: list[ProjectDef] = Field(default_factory=list)
+
+    def get_git_provider(self, name: str) -> GitProvider:
+        """Get a git provider by name.
+
+        Raises:
+            ValueError: If the provider is not defined in the manifest.
+        """
+        try:
+            return next(provider for provider in self.git_providers if provider.name == name)
+        except StopIteration:
+            raise ValueError(f"Git provider '{name}' is not defined in the manifest.") from None

--- a/dokli/state.py
+++ b/dokli/state.py
@@ -1,0 +1,209 @@
+"""Typed reads of the live state of a Dokploy instance.
+
+The state collector normalizes the raw API responses into typed models so that
+downstream features (``plan``, ``apply``, ``export``) can work symmetrically
+with the manifest models in :mod:`dokli.manifest`.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from dokli.api_client import APIClient
+from dokli.config import ConnectionConfig
+
+
+class LiveService(BaseModel):
+    """A service as it exists in the instance."""
+
+    service_id: str
+    app_name: str
+    type: Literal["compose", "application"]
+    name: str
+    description: str | None = None
+    source_type: str | None = None
+    provider: str | None = Field(default=None, description="Git provider name (resolved).")
+    repository: str | None = None
+    owner: str | None = None
+    branch: str | None = None
+    build_type: str | None = None
+    dockerfile_location: str | None = None
+    docker_image: str | None = None
+    compose_path: str | None = None
+    server_id: str | None = None
+
+
+class LiveEnvironment(BaseModel):
+    """An environment within a project."""
+
+    environment_id: str
+    name: str
+    is_default: bool
+    services: list[LiveService] = Field(default_factory=list)
+
+
+class LiveProject(BaseModel):
+    """A project as it exists in the instance."""
+
+    project_id: str
+    name: str
+    description: str | None = None
+    environments: list[LiveEnvironment] = Field(default_factory=list)
+
+
+class LiveGitProvider(BaseModel):
+    """A git provider as it exists in the instance (credentials are write-only)."""
+
+    git_provider_id: str
+    name: str
+    provider: str
+    url: str | None = None
+    app_name: str | None = None
+    is_configured: bool
+    github_id: str | None = None
+    gitlab_id: str | None = None
+    gitea_id: str | None = None
+    bitbucket_id: str | None = None
+
+
+class LiveServer(BaseModel):
+    """A server (deployment node) in the instance."""
+
+    server_id: str
+    name: str
+
+
+class State(BaseModel):
+    """Normalized live state of a connection."""
+
+    connection: str
+    projects: list[LiveProject] = Field(default_factory=list)
+    git_providers: list[LiveGitProvider] = Field(default_factory=list)
+    servers: list[LiveServer] = Field(default_factory=list)
+
+
+def collect_state(connection: ConnectionConfig) -> State:
+    """Collect the live state of a connection."""
+    client = APIClient(connection)
+    raw_projects = client.request("GET", "project.all", {}).json()
+    raw_providers = client.request("GET", "git-provider.getAll", {}).json()
+    raw_servers = client.request("GET", "server.all", {}).json()
+
+    provider_map = _build_provider_map(raw_providers)
+
+    projects = [
+        _collect_project(client, raw_project, provider_map) for raw_project in raw_projects
+    ]
+
+    return State(
+        connection=connection.name,
+        projects=projects,
+        git_providers=[_collect_git_provider(raw) for raw in raw_providers],
+        servers=[_collect_server(raw) for raw in raw_servers],
+    )
+
+
+def _collect_project(client: APIClient, raw_project: dict[str, Any], provider_map: dict[str, str]) -> LiveProject:
+    detail = client.request("GET", "project.one", {"projectId": raw_project["projectId"]}).json()
+    environments = [
+        LiveEnvironment(
+            environment_id=environment["environmentId"],
+            name=environment.get("name") or "",
+            is_default=environment.get("isDefault", False),
+            services=[
+                *_collect_services("compose", environment.get("compose", []), provider_map),
+                *_collect_services("application", environment.get("applications", []), provider_map),
+            ],
+        )
+        for environment in detail.get("environments", [])
+    ]
+    return LiveProject(
+        project_id=detail["projectId"],
+        name=detail.get("name") or "",
+        description=detail.get("description"),
+        environments=environments,
+    )
+
+
+def _collect_services(
+    service_type: Literal["compose", "application"],
+    raw_services: list[dict[str, Any]],
+    provider_map: dict[str, str],
+) -> list[LiveService]:
+    services = []
+    for raw in raw_services:
+        service_id = raw.get("composeId") or raw.get("applicationId")
+        if not service_id:
+            continue
+        services.append(
+            LiveService(
+                service_id=service_id,
+                app_name=raw.get("appName") or "",
+                type=service_type,
+                name=raw.get("name") or "",
+                description=raw.get("description"),
+                source_type=raw.get("sourceType"),
+                provider=_resolve_provider(raw, provider_map),
+                repository=_first(raw, "repository", "gitlabRepository", "giteaRepository", "bitbucketRepository"),
+                owner=_first(raw, "owner", "gitlabOwner", "giteaOwner", "bitbucketOwner"),
+                branch=_first(raw, "branch", "gitlabBranch", "giteaBranch", "bitbucketBranch"),
+                build_type=raw.get("buildType"),
+                dockerfile_location=raw.get("dockerfileLocation"),
+                docker_image=raw.get("dockerImage"),
+                compose_path=raw.get("composePath"),
+                server_id=raw.get("serverId"),
+            )
+        )
+    return services
+
+
+def _collect_git_provider(raw: dict[str, Any]) -> LiveGitProvider:
+    subprovider = _first(raw, "github", "gitlab", "gitea", "bitbucket")
+    return LiveGitProvider(
+        git_provider_id=raw["gitProviderId"],
+        name=raw.get("name") or raw["gitProviderId"],
+        provider=raw.get("providerType") or "",
+        url=subprovider.get("url") if isinstance(subprovider, dict) else None,
+        app_name=subprovider.get("appName") if isinstance(subprovider, dict) else None,
+        is_configured=bool(raw.get("isConfigured")) or (
+            isinstance(subprovider, dict) and bool(subprovider.get("isConfigured"))
+        ),
+        github_id=(raw.get("github") or {}).get("githubId"),
+        gitlab_id=(raw.get("gitlab") or {}).get("gitlabId"),
+        gitea_id=(raw.get("gitea") or {}).get("giteaId"),
+        bitbucket_id=(raw.get("bitbucket") or {}).get("bitbucketId"),
+    )
+
+
+def _collect_server(raw: dict[str, Any]) -> LiveServer:
+    return LiveServer(server_id=raw["serverId"], name=raw.get("name") or raw["serverId"])
+
+
+def _build_provider_map(raw_providers: list[dict[str, Any]]) -> dict[str, str]:
+    """Map subtype id (githubId, ...) to provider name."""
+    mapping: dict[str, str] = {}
+    for raw in raw_providers:
+        name = raw.get("name")
+        if not name:
+            continue
+        for key in ("github", "gitlab", "gitea", "bitbucket"):
+            subtype = raw.get(key) or {}
+            subtype_id = subtype.get(f"{key}Id")
+            if subtype_id:
+                mapping[subtype_id] = name
+    return mapping
+
+
+def _resolve_provider(raw: dict[str, Any], provider_map: dict[str, str]) -> str | None:
+    for key in ("githubId", "gitlabId", "giteaId", "bitbucketId"):
+        subtype_id = raw.get(key)
+        if subtype_id:
+            return provider_map.get(subtype_id)
+    return None
+
+
+def _first(mapping: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if mapping.get(key) is not None:
+            return mapping[key]
+    return None

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,74 @@
+"""Manifest model tests."""
+
+import pytest
+import yaml
+
+from dokli.manifest import ApplicationService, ComposeService, Manifest
+
+
+def _load_manifest(raw_yaml: str) -> Manifest:
+    return Manifest.model_validate(yaml.safe_load(raw_yaml))
+
+
+class TestManifest:
+    """Manifest model tests."""
+
+    def test_parse_manifest(self):
+        """We expect to be able to parse a manifest from YAML."""
+        manifest = _load_manifest(
+            """
+            connection: prod
+            git_providers:
+              - name: github-main
+                provider: github
+            projects:
+              - name: myapp
+                services:
+                  - type: compose
+                    name: backend
+            """
+        )
+        assert manifest.connection == "prod"
+        assert manifest.git_providers[0].name == "github-main"
+        assert manifest.projects[0].name == "myapp"
+
+    def test_service_discriminated_union(self):
+        """We expect services to be discriminated by type."""
+        manifest = _load_manifest(
+            """
+            connection: prod
+            projects:
+              - name: myapp
+                services:
+                  - type: compose
+                    name: backend
+                  - type: application
+                    name: web
+            """
+        )
+        service = manifest.projects[0].services
+        assert isinstance(service[0], ComposeService)
+        assert isinstance(service[1], ApplicationService)
+
+    def test_get_git_provider_raises_for_unknown(self):
+        """We expect an error when a git provider is not defined."""
+        manifest = _load_manifest(
+            """
+            connection: prod
+            projects: []
+            """
+        )
+        with pytest.raises(ValueError, match="not defined"):
+            manifest.get_git_provider("missing")
+
+    def test_get_git_provider_by_name(self):
+        """We expect to look up git providers by name."""
+        manifest = _load_manifest(
+            """
+            connection: prod
+            git_providers:
+              - name: github-main
+                provider: github
+            """
+        )
+        assert manifest.get_git_provider("github-main").provider == "github"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,138 @@
+"""State collection tests."""
+
+from dokli.config import ConnectionConfig
+from dokli.state import State, collect_state
+
+
+class FakeResponse:
+    """Minimal httpx.Response stand-in for tests."""
+
+    def __init__(self, data):
+        """Initialize with the payload to return from json()."""
+        self._data = data
+
+    def json(self):
+        """Return the canned payload."""
+        return self._data
+
+
+def _connection() -> ConnectionConfig:
+    return ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+
+
+def _responses():
+    return {
+        "project.all": [{"projectId": "p1", "name": "myapp", "description": None}],
+        "project.one": {
+            "projectId": "p1",
+            "name": "myapp",
+            "description": None,
+            "environments": [
+                {
+                    "environmentId": "e1",
+                    "name": "production",
+                    "isDefault": True,
+                    "compose": [
+                        {
+                            "composeId": "c1",
+                            "appName": "backend",
+                            "name": "backend",
+                            "sourceType": "github",
+                            "githubId": "gh1",
+                            "repository": "jonykalavera/backend",
+                            "owner": "jonykalavera",
+                            "branch": "main",
+                            "composePath": "docker-compose.yml",
+                            "serverId": "srv1",
+                            "description": None,
+                        }
+                    ],
+                    "applications": [
+                        {
+                            "applicationId": "a1",
+                            "appName": "web",
+                            "name": "web",
+                            "sourceType": "github",
+                            "githubId": "gh1",
+                            "repository": "jonykalavera/web",
+                            "owner": "jonykalavera",
+                            "branch": "main",
+                            "buildType": "dockerfile",
+                            "dockerfileLocation": "./web/Dockerfile",
+                            "serverId": "srv1",
+                            "description": None,
+                        }
+                    ],
+                }
+            ],
+        },
+        "git-provider.getAll": [
+            {
+                "gitProviderId": "gp1",
+                "name": "github-main",
+                "providerType": "github",
+                "isConfigured": True,
+                "github": {"githubId": "gh1", "githubAppName": "dokli", "isConfigured": True},
+                "gitlab": None,
+                "gitea": None,
+                "bitbucket": None,
+            }
+        ],
+        "server.all": [{"serverId": "srv1", "name": "local"}],
+    }
+
+
+class TestCollectState:
+    """State collection tests."""
+
+    def test_collect_state(self, mocker):
+        """We expect a normalized state with projects, services and providers."""
+        responses = _responses()
+        client = mocker.Mock()
+        client.request.side_effect = lambda _method, path, _params: FakeResponse(responses[path])
+        mocker.patch("dokli.state.APIClient", return_value=client)
+
+        state = collect_state(_connection())
+
+        assert isinstance(state, State)
+        assert state.connection == "test-env"
+        assert len(state.servers) == 1
+        assert state.servers[0].name == "local"
+
+        project = state.projects[0]
+        assert project.project_id == "p1"
+        assert len(project.environments) == 1
+        environment = project.environments[0]
+        assert environment.is_default
+        assert [s.name for s in environment.services] == ["backend", "web"]
+
+        compose = environment.services[0]
+        assert compose.type == "compose"
+        assert compose.provider == "github-main"
+        assert compose.repository == "jonykalavera/backend"
+        assert compose.compose_path == "docker-compose.yml"
+
+        application = environment.services[1]
+        assert application.type == "application"
+        assert application.build_type == "dockerfile"
+        assert application.dockerfile_location == "./web/Dockerfile"
+
+        provider = state.git_providers[0]
+        assert provider.name == "github-main"
+        assert provider.github_id == "gh1"
+        assert provider.is_configured
+
+    def test_request_paths(self, mocker):
+        """We expect state to read projects, git providers and servers."""
+        responses = _responses()
+        client = mocker.Mock()
+        client.request.side_effect = lambda _method, path, _params: FakeResponse(responses[path])
+        mocker.patch("dokli.state.APIClient", return_value=client)
+
+        collect_state(_connection())
+
+        paths = [call.args[1] for call in client.request.call_args_list]
+        assert "project.all" in paths
+        assert "project.one" in paths
+        assert "git-provider.getAll" in paths
+        assert "server.all" in paths


### PR DESCRIPTION
Part of #20 — Phase 1 of Dokli as Code.

## What's in this PR

- **`dokli/manifest.py`** — declarative manifest models (pydantic):
  - `Manifest` { connection, server?, git_providers[], projects[] }
  - `GitProvider` (metadata only + `token_cmd` external reference)
  - `ProjectDef` → services with a discriminated union `ComposeService | ApplicationService`
- **`dokli/state.py`** — typed read of a live instance via `APIClient`:
  - Reads `project.all` + `project.one` (detail), `git-provider.getAll`, `server.all`
  - Normalizes into `State` (projects → environments → services) with git provider resolution (subtype FK → provider name)
  - This gives `plan`/`apply`/`export` a symmetric view with the manifest models.
- **`dokli state [connection]`** command — dumps the normalized live state as YAML.

## Design notes

- Services live in **environments** inside projects (Dokploy 0.24+/canary), so state models that layer explicitly.
- Git provider credentials are **write-only** in Dokploy's API; state only captures metadata + `isConfigured`.

## Verification

- `make lint` ✓ (ruff + mypy)
- `make test` → 15 passed ✓ (`state.py` 91% coverage)
- `dokli --help` shows the new `state` command ✓

Next phases (separate PRs): `plan` (diff) → `apply` (engine) → `export` → `init` + docs.
