### PR TITLE
Fix OpenAPI param names + state collector route (test against live instance)

### DIFF
--- a/dokli/openapi_cli.py
+++ b/dokli/openapi_cli.py
@@ -1,5 +1,6 @@
 """OpenAPI CLI."""
 
+import keyword
 import re
 from inspect import Parameter, Signature
 from typing import Annotated, Any
@@ -34,13 +35,26 @@ def _camel_case_to_snake_case(camel_case_str):
     return re.sub(r"(?<!^)(?=[A-Z])", "_", camel_case_str).lower()
 
 
+def _safe_param_name(name: str) -> str:
+    """Return a valid Python parameter name for an OpenAPI parameter.
+
+    Some schemas use reserved words (e.g. ``from``) or characters that are not
+    valid in Python identifiers. Invalid names are prefixed with ``p_``.
+    """
+    name = _camel_case_to_snake_case(name)
+    name = re.sub(r"\W", "_", name)
+    if keyword.iskeyword(name) or not name.isidentifier():
+        name = f"p_{name}"
+    return name
+
+
 def _api_command_factory(connection, route, method="GET", params=None, request_body=None, client=None):
     """Create a command from an OpenAPI endpoint."""
     # Create a list of parameters for the signature
-    param_hints = {p["name"]: _infer_param_type(p) for p in params}
-    original_name = {_camel_case_to_snake_case(x["name"]): x["name"] for x in params}
+    original_name = {_safe_param_name(x["name"]): x["name"] for x in params}
+    param_hints = {_safe_param_name(p["name"]): _infer_param_type(p) for p in params}
     parameters = [
-        Parameter(_camel_case_to_snake_case(name), Parameter.KEYWORD_ONLY, annotation=typ)
+        Parameter(name, Parameter.KEYWORD_ONLY, annotation=typ)
         for name, typ in param_hints.items()
     ]
     if request_body and request_body.get("required", False):

--- a/dokli/state.py
+++ b/dokli/state.py
@@ -86,7 +86,7 @@ def collect_state(connection: ConnectionConfig) -> State:
     """Collect the live state of a connection."""
     client = APIClient(connection)
     raw_projects = client.request("GET", "project.all", {}).json()
-    raw_providers = client.request("GET", "git-provider.getAll", {}).json()
+    raw_providers = client.request("GET", "gitProvider.getAll", {}).json()
     raw_servers = client.request("GET", "server.all", {}).json()
 
     provider_map = _build_provider_map(raw_providers)

--- a/tests/test_openapi_cli.py
+++ b/tests/test_openapi_cli.py
@@ -1,0 +1,21 @@
+"""OpenAPI CLI tests."""
+
+from dokli.openapi_cli import _safe_param_name
+
+
+class TestSafeParamName:
+    """Safe parameter name tests."""
+
+    def test_keeps_valid_names(self):
+        """We expect valid names to be unchanged."""
+        assert _safe_param_name("projectId") == "project_id"
+        assert _safe_param_name("tail") == "tail"
+
+    def test_prefixes_reserved_keywords(self):
+        """We expect reserved words to be prefixed."""
+        assert _safe_param_name("from") == "p_from"
+        assert _safe_param_name("to") == "to"
+
+    def test_sanitizes_invalid_characters(self):
+        """We expect invalid characters to be replaced."""
+        assert _safe_param_name("app-name") == "app_name"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -66,7 +66,7 @@ def _responses():
                 }
             ],
         },
-        "git-provider.getAll": [
+        "gitProvider.getAll": [
             {
                 "gitProviderId": "gp1",
                 "name": "github-main",
@@ -134,5 +134,5 @@ class TestCollectState:
         paths = [call.args[1] for call in client.request.call_args_list]
         assert "project.all" in paths
         assert "project.one" in paths
-        assert "git-provider.getAll" in paths
+        assert "gitProvider.getAll" in paths
         assert "server.all" in paths


### PR DESCRIPTION
Closes #26

Discovered while testing `dokli state` against a live Dokploy instance (`dokploy.meche.lan`).

## Changes

1. **`dokli/openapi_cli.py`** — sanitize OpenAPI parameter names before building the command signature. Newer Dokploy OpenAPI documents include a parameter named `from`, which is a Python keyword → `ValueError: 'from' is not a valid parameter name` at import time, breaking the whole CLI. Now names are made valid identifiers (`p_from`) while preserving the original name for the API request.
2. **`dokli/state.py`** — the git provider route is `gitProvider.getAll` (camelCase entity), not `git-provider.getAll`; fixed the collector.

## Verification

- `dokli state meche` against the real instance works (returns git providers + projects → environments → services).
- `make lint` ✓, `make test` → 18 passed ✓.

This is a bugfix PR; after merging I'll resume **F2 (`plan`/diff)** on `DOKLI-20-f2`.
