### PR TITLE
Dokli as Code (f2): dokli plan (declarative diff)

### DIFF
--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -5,8 +5,11 @@ from typing import Any
 import typer
 import yaml
 from rich import print as rprint
+from rich.table import Table
 
 from dokli.config import Config, ConnectionConfig
+from dokli.diff import build_plan
+from dokli.manifest import Manifest
 from dokli.openapi_cli import register_connections
 from dokli.state import collect_state
 
@@ -54,6 +57,30 @@ def state_command(connection_name: str | None = typer.Argument(None, help="Conne
     connection = _get_connection(connection_name)
     live_state = collect_state(connection)
     rprint(yaml.dump(live_state.model_dump(mode="json")))
+
+
+@app.command(name="plan")
+def plan_command(
+    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+) -> None:
+    """Show what would change between the manifest and the live instance."""
+    manifest = Manifest.load(manifest_file)
+    connection = _get_connection(manifest.connection)
+    live_state = collect_state(connection)
+    plan = build_plan(manifest, live_state)
+    if not plan.has_changes:
+        rprint("[green]No changes.[/green]")
+        return
+    table = Table(title=f"Plan for {manifest.connection}")
+    table.add_column("Action")
+    table.add_column("Kind")
+    table.add_column("Project")
+    table.add_column("Name")
+    table.add_column("Details")
+    for item in plan.items:
+        details = ", ".join(item.changed) if item.changed else item.reason
+        table.add_row(item.action, item.kind, item.project, item.name, details)
+    rprint(table)
 
 
 @app.callback(no_args_is_help=True)

--- a/dokli/diff.py
+++ b/dokli/diff.py
@@ -1,0 +1,202 @@
+"""Declarative diff between a manifest and the live state of an instance."""
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from dokli.manifest import ApplicationService, ComposeService, GitSource, Manifest, Service
+from dokli.state import LiveEnvironment, LiveProject, LiveService, State
+
+
+class PlanItem(BaseModel):
+    """A single planned change."""
+
+    action: Literal["create", "update", "validate"]
+    kind: Literal["project", "compose", "application", "git_provider"]
+    project: str = ""
+    name: str
+    changed: list[str] = Field(default_factory=list)
+    reason: str = ""
+
+
+class Plan(BaseModel):
+    """The diff between a manifest and the live state."""
+
+    connection: str
+    items: list[PlanItem] = Field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        """Whether any change is planned."""
+        return bool(self.items)
+
+
+def build_plan(manifest: Manifest, state: State) -> Plan:
+    """Build a plan comparing the manifest against the live state."""
+    items: list[PlanItem] = []
+    live_projects = {project.name: project for project in state.projects}
+
+    for project_def in manifest.projects:
+        live_project = live_projects.get(project_def.name)
+        if live_project is None:
+            items.append(
+                PlanItem(
+                    action="create",
+                    kind="project",
+                    project=project_def.name,
+                    name=project_def.name,
+                    reason="Project does not exist.",
+                )
+            )
+            for service_def in project_def.services:
+                items.append(
+                    PlanItem(
+                        action="create",
+                        kind=service_def.type,
+                        project=project_def.name,
+                        name=service_def.name,
+                        reason="Service will be created with the project.",
+                    )
+                )
+            continue
+
+        default_environment = _default_environment(live_project)
+        live_services = {
+            service.name: service for service in (default_environment.services if default_environment else [])
+        }
+
+        for service_def in project_def.services:
+            live_service = live_services.get(service_def.name)
+            if live_service is None:
+                items.append(
+                    PlanItem(
+                        action="create",
+                        kind=service_def.type,
+                        project=project_def.name,
+                        name=service_def.name,
+                        reason="Service does not exist.",
+                    )
+                )
+            else:
+                changed = _service_changes(service_def, live_service)
+                if changed:
+                    items.append(
+                        PlanItem(
+                            action="update",
+                            kind=service_def.type,
+                            project=project_def.name,
+                            name=service_def.name,
+                            changed=changed,
+                        )
+                    )
+
+    _plan_git_providers(manifest, state, items)
+
+    return Plan(connection=state.connection, items=items)
+
+
+def _plan_git_providers(manifest: Manifest, state: State, items: list[PlanItem]) -> None:
+    live_providers = {provider.name: provider for provider in state.git_providers}
+    for provider_def in manifest.git_providers:
+        live_provider = live_providers.get(provider_def.name)
+        if live_provider is None:
+            items.append(
+                PlanItem(
+                    action="validate",
+                    kind="git_provider",
+                    name=provider_def.name,
+                    reason="Git provider not found. It cannot be created via the API; configure it in the instance.",
+                )
+            )
+        elif live_provider.provider != provider_def.provider:
+            items.append(
+                PlanItem(
+                    action="validate",
+                    kind="git_provider",
+                    name=provider_def.name,
+                    reason=(
+                        f"Provider type mismatch: manifest '{provider_def.provider}' "
+                        f"vs instance '{live_provider.provider}'."
+                    ),
+                )
+            )
+        elif not live_provider.is_configured:
+            items.append(
+                PlanItem(
+                    action="validate",
+                    kind="git_provider",
+                    name=provider_def.name,
+                    reason="Git provider is not configured.",
+                )
+            )
+
+
+def _default_environment(project: LiveProject) -> LiveEnvironment | None:
+    return next((environment for environment in project.environments if environment.is_default), None)
+
+
+def _service_changes(service_def: Service, live: LiveService) -> list[str]:
+    changes: list[str] = []
+    if isinstance(service_def, ComposeService):
+        _compose_changes(service_def, live, changes)
+    else:
+        _application_changes(service_def, live, changes)
+    return changes
+
+
+def _compose_changes(service_def: ComposeService, live: LiveService, changes: list[str]) -> None:
+    if service_def.description is not None and (live.description or "") != service_def.description:
+        changes.append("description")
+    if service_def.source:
+        if _source_changed(service_def.source, live):
+            changes.append("source")
+        if service_def.compose_path and live.compose_path != service_def.compose_path:
+            changes.append("compose_path")
+    elif service_def.compose_file:
+        if (live.compose_file or "") != resolve_compose_file(service_def.compose_file):
+            changes.append("compose_file")
+    if service_def.command is not None and (live.command or "") != service_def.command:
+        changes.append("command")
+    if service_def.env is not None and (live.env or "") != service_def.env:
+        changes.append("env")
+
+
+def _application_changes(service_def: ApplicationService, live: LiveService, changes: list[str]) -> None:
+    if service_def.description is not None and (live.description or "") != service_def.description:
+        changes.append("description")
+    if service_def.source:
+        if _source_changed(service_def.source, live):
+            changes.append("source")
+    elif service_def.image and live.docker_image != service_def.image:
+        changes.append("image")
+    if service_def.build_type and live.build_type != service_def.build_type:
+        changes.append("build_type")
+    if service_def.dockerfile_location and live.dockerfile_location != service_def.dockerfile_location:
+        changes.append("dockerfile_location")
+    if service_def.build_path and live.build_path != service_def.build_path:
+        changes.append("build_path")
+    if service_def.env is not None and (live.env or "") != service_def.env:
+        changes.append("env")
+
+
+def _source_changed(source: GitSource, live: LiveService) -> bool:
+    """Compare a manifest source with a live service."""
+    if live.source_type != source.provider:
+        return True
+    if live.provider != source.provider:
+        return True
+    owner, _, repository = source.repository.partition("/")
+    if repository and live.repository != repository:
+        return True
+    if owner and live.owner != owner:
+        return True
+    return live.branch != source.branch
+
+
+def resolve_compose_file(value: str) -> str:
+    """Return compose YAML content, reading from disk when the value is a path."""
+    path = Path(value)
+    if path.is_file():
+        return path.read_text()
+    return value

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -6,6 +6,7 @@ instance. See :issue:`20`.
 
 from typing import Annotated, Literal
 
+import yaml
 from pydantic import BaseModel, Field
 
 
@@ -110,3 +111,9 @@ class Manifest(BaseModel):
             return next(provider for provider in self.git_providers if provider.name == name)
         except StopIteration:
             raise ValueError(f"Git provider '{name}' is not defined in the manifest.") from None
+
+    @classmethod
+    def load(cls, path: str) -> "Manifest":
+        """Load a manifest from a YAML file."""
+        with open(path) as file:
+            return cls.model_validate(yaml.safe_load(file))

--- a/dokli/state.py
+++ b/dokli/state.py
@@ -29,7 +29,11 @@ class LiveService(BaseModel):
     build_type: str | None = None
     dockerfile_location: str | None = None
     docker_image: str | None = None
+    build_path: str | None = None
     compose_path: str | None = None
+    compose_file: str | None = None
+    command: str | None = None
+    env: str | None = None
     server_id: str | None = None
 
 
@@ -150,7 +154,11 @@ def _collect_services(
                 build_type=raw.get("buildType"),
                 dockerfile_location=raw.get("dockerfileLocation"),
                 docker_image=raw.get("dockerImage"),
+                build_path=raw.get("buildPath"),
                 compose_path=raw.get("composePath"),
+                compose_file=raw.get("composeFile"),
+                command=raw.get("command"),
+                env=raw.get("env"),
                 server_id=raw.get("serverId"),
             )
         )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,165 @@
+"""Diff/plan tests."""
+
+from dokli.diff import build_plan
+from dokli.manifest import Manifest
+from dokli.state import LiveEnvironment, LiveGitProvider, LiveProject, LiveService, State
+
+
+def _state(
+    projects: list[LiveProject] | None = None,
+    providers: list[LiveGitProvider] | None = None,
+) -> State:
+    return State(connection="test-env", projects=projects or [], git_providers=providers or [], servers=[])
+
+
+def _compose_live(name: str, service_id: str, **overrides) -> LiveService:
+    defaults = {
+        "service_id": service_id,
+        "app_name": name,
+        "type": "compose",
+        "name": name,
+        "source_type": "raw",
+        "compose_file": "version: '3'",
+        "compose_path": "docker-compose.yml",
+    }
+    defaults.update(overrides)
+    return LiveService(**defaults)
+
+
+def _project_live(name: str, services: list[LiveService]) -> LiveProject:
+    return LiveProject(
+        project_id=name,
+        name=name,
+        environments=[
+            LiveEnvironment(
+                environment_id="e1",
+                name="production",
+                is_default=True,
+                services=services,
+            )
+        ],
+    )
+
+
+class TestBuildPlan:
+    """Plan building tests."""
+
+    def test_project_to_create(self):
+        """We expect a plan with creates when the project is missing."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [{"name": "new-app", "services": [{"type": "compose", "name": "backend"}]}],
+            }
+        )
+        plan = build_plan(manifest, _state(projects=[]))
+
+        actions = [item.action for item in plan.items]
+        assert actions == ["create", "create"]
+        assert plan.items[0].kind == "project"
+        assert plan.items[1].kind == "compose"
+
+    def test_service_to_create(self):
+        """We expect a create when the service is missing in an existing project."""
+        manifest = Manifest.model_validate(
+            {"connection": "test-env", "projects": [{"name": "app", "services": [{"type": "compose", "name": "new"}]}]}
+        )
+        state = _state(projects=[_project_live("app", [_compose_live("existing", "s1")])])
+
+        plan = build_plan(manifest, state)
+
+        assert plan.has_changes
+        assert plan.items[0].action == "create"
+        assert plan.items[0].name == "new"
+
+    def test_no_changes(self):
+        """We expect an empty plan when manifest matches the live state."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {"type": "compose", "name": "backend", "compose_file": "version: '3'"},
+                        ],
+                    }
+                ],
+            }
+        )
+        state = _state(projects=[_project_live("app", [_compose_live("backend", "s1")])])
+
+        plan = build_plan(manifest, state)
+
+        assert not plan.has_changes
+
+    def test_service_update_changes(self):
+        """We expect an update with the changed fields listed."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [{"type": "compose", "name": "backend", "compose_file": "version: '3.8'"}],
+                    }
+                ],
+            }
+        )
+        state = _state(projects=[_project_live("app", [_compose_live("backend", "s1")])])
+
+        plan = build_plan(manifest, state)
+
+        assert plan.items[0].action == "update"
+        assert plan.items[0].changed == ["compose_file"]
+
+    def test_git_provider_missing(self):
+        """We expect a validate item when a git provider is missing."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "git_providers": [{"name": "github-main", "provider": "github"}],
+            }
+        )
+        plan = build_plan(manifest, _state(providers=[]))
+
+        assert plan.items[0].action == "validate"
+        assert plan.items[0].kind == "git_provider"
+
+    def test_git_provider_not_configured(self):
+        """We expect a validate item when a git provider is not configured."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "git_providers": [{"name": "github-main", "provider": "github"}],
+            }
+        )
+        provider = LiveGitProvider(
+            git_provider_id="gp1",
+            name="github-main",
+            provider="github",
+            is_configured=False,
+        )
+        plan = build_plan(manifest, _state(providers=[provider]))
+
+        assert plan.items[0].action == "validate"
+        assert "not configured" in plan.items[0].reason
+
+    def test_git_provider_type_mismatch(self):
+        """We expect a validate item when provider types differ."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "git_providers": [{"name": "github-main", "provider": "github"}],
+            }
+        )
+        provider = LiveGitProvider(
+            git_provider_id="gp1",
+            name="github-main",
+            provider="gitlab",
+            is_configured=True,
+        )
+        plan = build_plan(manifest, _state(providers=[provider]))
+
+        assert plan.items[0].action == "validate"
+        assert "type mismatch" in plan.items[0].reason


### PR DESCRIPTION
Part of #20 — Phase 2 of Dokli as Code.

## What's in this PR

- **`dokli/diff.py`** — `build_plan(manifest, state)` produces a typed `Plan`:
  - `create` for missing projects/services (children of a new project are grouped under it)
  - `update` with the list of changed fields (source, compose_file, compose_path, build_type, dockerfile_location, build_path, image, command, env, description)
  - `validate` for git providers that are missing, unconfigured, or type-mismatched (they can't be created via the API)
- **`dokli/state.py`** — `LiveService` now also captures `compose_file`, `command`, `env`, `build_path` so the diff can compare them.
- **`dokli/manifest.py`** — added `Manifest.load(path)` (YAML → model).
- **`dokli plan [-f dokploy.yaml]`** command — renders the plan as a rich table.
- Manifest filename is **`dokploy.yaml`** (separate from the connection config `dokli.yaml`; the `--file` flag overrides).

## Verified against the live instance (`dokploy.meche.lan`)

```
Plan for meche
update  compose  data        monitoring  compose_file
create  project  dokli-demo  dokli-demo  Project does not exist.
create  compose  dokli-demo  hello       Service will be created with the project.
```
Git provider `meche-dokploy` matched (exists, configured, github) → no validate warnings.

## Verification

- `make lint` ✓, `make test` → 25 passed ✓.

Next phase: **F3 `apply`** (idempotent engine) on `DOKLI-20-f3`.
