### PR TITLE
Dokli as Code (f3): dokli apply (idempotent engine)

### DIFF
--- a/dokli/api_client.py
+++ b/dokli/api_client.py
@@ -67,11 +67,19 @@ class APIClient:
 
         formatted_path = path.format(**path_params)
 
+        request_kwargs: dict[str, Any] = {
+            "params": query_params,
+            "headers": self.headers,
+        }
+        if body is not None:
+            if isinstance(body, dict | list):
+                request_kwargs["json"] = body
+            else:
+                request_kwargs["data"] = body
+
         response = getattr(self.session, method.lower())(
             url=f"{self.base_url}{formatted_path}",
-            params=query_params,
-            headers=self.headers,
-            **({"data": body} if body else {}),
+            **request_kwargs,
         )
         response.raise_for_status()
         return response

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -1,0 +1,328 @@
+"""Apply a manifest to a Dokploy instance (idempotent, additive).
+
+Apply never deletes resources that are not in the manifest. Services are
+created with the minimal payload the API requires, then fully updated to the
+desired state (the API splits ``create`` and ``update`` inputs).
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from dokli.api_client import APIClient
+from dokli.config import ConnectionConfig
+from dokli.diff import resolve_compose_file
+from dokli.manifest import ApplicationService, ComposeService, Manifest, Service
+from dokli.state import LiveGitProvider, LiveProject, LiveService, collect_state
+
+
+class ApplyAction(BaseModel):
+    """A single apply action."""
+
+    action: Literal["create", "update", "validate", "skip"]
+    kind: Literal["project", "compose", "application", "git_provider"]
+    project: str = ""
+    name: str
+    details: str = ""
+
+
+class ApplyReport(BaseModel):
+    """Report of what apply did or would do."""
+
+    actions: list[ApplyAction] = Field(default_factory=list)
+
+
+class Applier:
+    """Applies a manifest to a connection."""
+
+    def __init__(self, manifest: Manifest, connection: ConnectionConfig, deploy: bool = False):
+        """Initialize the applier with a manifest and connection."""
+        self.manifest = manifest
+        self.connection = connection
+        self.client = APIClient(connection)
+        self.deploy = deploy
+        self.report = ApplyReport()
+        self._live_providers: dict[str, LiveGitProvider] = {}
+
+    def run(self, dry_run: bool = False) -> ApplyReport:
+        """Apply the manifest, optionally only planning (dry_run)."""
+        state = collect_state(self.connection, client=self.client)
+        self._live_providers = {provider.name: provider for provider in state.git_providers}
+        self._validate_git_providers()
+
+        live_projects = {project.name: project for project in state.projects}
+        for project_def in self.manifest.projects:
+            live_project = live_projects.get(project_def.name)
+            if live_project is None:
+                self._create_project(project_def, dry_run)
+            else:
+                self._apply_to_project(project_def, live_project, dry_run)
+
+        return self.report
+
+    def _validate_git_providers(self) -> None:
+        for provider_def in self.manifest.git_providers:
+            live = self._live_providers.get(provider_def.name)
+            if live is None:
+                self.report.actions.append(
+                    ApplyAction(
+                        action="validate",
+                        kind="git_provider",
+                        name=provider_def.name,
+                        details="Git provider not found in the instance. Configure it manually.",
+                    )
+                )
+            elif live.provider != provider_def.provider:
+                self.report.actions.append(
+                    ApplyAction(
+                        action="validate",
+                        kind="git_provider",
+                        name=provider_def.name,
+                        details=(
+                            f"Type mismatch: manifest '{provider_def.provider}' " f"vs instance '{live.provider}'."
+                        ),
+                    )
+                )
+            elif not live.is_configured:
+                self.report.actions.append(
+                    ApplyAction(
+                        action="validate",
+                        kind="git_provider",
+                        name=provider_def.name,
+                        details="Git provider is not configured in the instance.",
+                    )
+                )
+
+    def _create_project(self, project_def, dry_run: bool) -> None:
+        if dry_run:
+            self.report.actions.append(
+                ApplyAction(action="create", kind="project", project=project_def.name, name=project_def.name)
+            )
+            for service_def in project_def.services:
+                self.report.actions.append(
+                    ApplyAction(
+                        action="create", kind=service_def.type, project=project_def.name, name=service_def.name
+                    )
+                )
+            return
+
+        payload: dict[str, Any] = {"name": project_def.name}
+        if project_def.description:
+            payload["description"] = project_def.description
+        response = self.client.request("POST", "project.create", {"body": payload}).json()
+        environment_id = response["environment"]["environmentId"]
+        self.report.actions.append(
+            ApplyAction(action="create", kind="project", project=project_def.name, name=project_def.name)
+        )
+        for service_def in project_def.services:
+            self._create_service(project_def.name, service_def, environment_id, dry_run=False)
+
+    def _apply_to_project(self, project_def, live_project: LiveProject, dry_run: bool) -> None:
+        default_environment = next(
+            (environment for environment in live_project.environments if environment.is_default),
+            None,
+        )
+        if default_environment is None:
+            self.report.actions.append(
+                ApplyAction(
+                    action="skip",
+                    kind="project",
+                    project=project_def.name,
+                    name=project_def.name,
+                    details="No default environment found.",
+                )
+            )
+            return
+        live_services = {service.name: service for service in default_environment.services}
+        for service_def in project_def.services:
+            live_service = live_services.get(service_def.name)
+            if live_service is None:
+                self._create_service(project_def.name, service_def, default_environment.environment_id, dry_run)
+            else:
+                self._update_service(project_def.name, service_def, live_service, dry_run)
+
+    def _create_service(self, project_name: str, service_def: Service, environment_id: str, dry_run: bool) -> None:
+        if dry_run:
+            self.report.actions.append(
+                ApplyAction(action="create", kind=service_def.type, project=project_name, name=service_def.name)
+            )
+            return
+        try:
+            if isinstance(service_def, ComposeService):
+                service_id = self._create_compose(service_def, environment_id)
+            else:
+                service_id = self._create_application(service_def, environment_id)
+            payload = self._service_desired_payload(service_def, None)
+            self._apply_update(service_def.type, service_id, payload)
+        except ValueError as err:
+            self.report.actions.append(
+                ApplyAction(
+                    action="skip",
+                    kind=service_def.type,
+                    project=project_name,
+                    name=service_def.name,
+                    details=str(err),
+                )
+            )
+            return
+        self.report.actions.append(
+            ApplyAction(action="create", kind=service_def.type, project=project_name, name=service_def.name)
+        )
+        if self.deploy:
+            self._deploy(service_def.type, service_id)
+
+    def _update_service(
+        self, project_name: str, service_def: Service, live_service: LiveService, dry_run: bool
+    ) -> None:
+        try:
+            payload = self._service_desired_payload(service_def, live_service)
+        except ValueError as err:
+            self.report.actions.append(
+                ApplyAction(
+                    action="skip",
+                    kind=service_def.type,
+                    project=project_name,
+                    name=service_def.name,
+                    details=str(err),
+                )
+            )
+            return
+        if not payload:
+            return
+        if dry_run:
+            self.report.actions.append(
+                ApplyAction(
+                    action="update",
+                    kind=service_def.type,
+                    project=project_name,
+                    name=service_def.name,
+                    details=", ".join(sorted(payload)),
+                )
+            )
+            return
+        self._apply_update(service_def.type, live_service.service_id, payload)
+        self.report.actions.append(
+            ApplyAction(action="update", kind=service_def.type, project=project_name, name=service_def.name)
+        )
+        if self.deploy:
+            self._deploy(service_def.type, live_service.service_id)
+
+    def _create_compose(self, service_def: ComposeService, environment_id: str) -> str:
+        payload: dict[str, Any] = {
+            "name": service_def.name,
+            "environmentId": environment_id,
+            "composeType": "docker-compose",
+        }
+        if service_def.description:
+            payload["description"] = service_def.description
+        response = self.client.request("POST", "compose.create", {"body": payload}).json()
+        return response["composeId"]
+
+    def _create_application(self, service_def: ApplicationService, environment_id: str) -> str:
+        payload: dict[str, Any] = {
+            "name": service_def.name,
+            "environmentId": environment_id,
+        }
+        if service_def.description:
+            payload["description"] = service_def.description
+        response = self.client.request("POST", "application.create", {"body": payload}).json()
+        return response["applicationId"]
+
+    def _apply_update(self, service_type: str, service_id: str, payload: dict[str, Any]) -> None:
+        if not payload:
+            return
+        id_field = {"compose": "composeId", "application": "applicationId"}[service_type]
+        payload[id_field] = service_id
+        self.client.request("POST", f"{service_type}.update", {"body": payload})
+
+    def _deploy(self, service_type: str, service_id: str) -> None:
+        id_field = {"compose": "composeId", "application": "applicationId"}[service_type]
+        self.client.request("POST", f"{service_type}.deploy", {"body": {id_field: service_id}})
+
+    def _service_desired_payload(self, service_def: Service, live: LiveService | None) -> dict[str, Any]:
+        """Return the desired fields for a service, skipping fields that already match."""
+        if isinstance(service_def, ComposeService):
+            return self._compose_payload(service_def, live)
+        return self._application_payload(service_def, live)
+
+    def _compose_payload(self, service_def: ComposeService, live: LiveService | None) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if service_def.description is not None and (
+            live is None or (live.description or "") != service_def.description
+        ):
+            payload["description"] = service_def.description
+        if service_def.source:
+            provider_type, subtype_id = self._resolve_provider(service_def.source.provider)
+            if live is None or live.source_type != provider_type or live.provider != service_def.source.provider:
+                payload["sourceType"] = provider_type
+                payload[f"{provider_type}Id"] = subtype_id
+            owner, _, repository = service_def.source.repository.partition("/")
+            if live is None or live.owner != owner:
+                payload["owner"] = owner
+            if live is None or live.repository != repository:
+                payload["repository"] = repository
+            if live is None or live.branch != service_def.source.branch:
+                payload["branch"] = service_def.source.branch
+            if service_def.compose_path and (live is None or live.compose_path != service_def.compose_path):
+                payload["composePath"] = service_def.compose_path
+        elif service_def.compose_file:
+            content = resolve_compose_file(service_def.compose_file)
+            if live is None or (live.compose_file or "") != content:
+                payload["composeFile"] = content
+                payload["sourceType"] = "raw"
+        if service_def.command is not None and (live is None or (live.command or "") != service_def.command):
+            payload["command"] = service_def.command
+        if service_def.env is not None and (live is None or (live.env or "") != service_def.env):
+            payload["env"] = service_def.env
+        return payload
+
+    def _application_payload(self, service_def: ApplicationService, live: LiveService | None) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if service_def.description is not None and (
+            live is None or (live.description or "") != service_def.description
+        ):
+            payload["description"] = service_def.description
+        if service_def.source:
+            provider_type, subtype_id = self._resolve_provider(service_def.source.provider)
+            if live is None or live.source_type != provider_type or live.provider != service_def.source.provider:
+                payload["sourceType"] = provider_type
+                payload[f"{provider_type}Id"] = subtype_id
+            owner, _, repository = service_def.source.repository.partition("/")
+            if live is None or live.owner != owner:
+                payload["owner"] = owner
+            if live is None or live.repository != repository:
+                payload["repository"] = repository
+            if live is None or live.branch != service_def.source.branch:
+                payload["branch"] = service_def.source.branch
+        elif service_def.image and (live is None or live.docker_image != service_def.image):
+            payload["sourceType"] = "docker"
+            payload["dockerImage"] = service_def.image
+        if service_def.build_type and (live is None or live.build_type != service_def.build_type):
+            payload["buildType"] = service_def.build_type
+        if service_def.dockerfile_location and (
+            live is None or live.dockerfile_location != service_def.dockerfile_location
+        ):
+            payload["dockerfileLocation"] = service_def.dockerfile_location
+        if service_def.build_path and (live is None or live.build_path != service_def.build_path):
+            payload["buildPath"] = service_def.build_path
+        if service_def.env is not None and (live is None or (live.env or "") != service_def.env):
+            payload["env"] = service_def.env
+        return payload
+
+    def _resolve_provider(self, name: str) -> tuple[str, str]:
+        """Resolve a manifest provider name to (provider type, subtype id)."""
+        provider_def = self.manifest.get_git_provider(name)
+        live = self._live_providers.get(name)
+        if live is None:
+            raise ValueError(f"Git provider '{name}' is not configured in the instance.")
+        if live.provider != provider_def.provider:
+            raise ValueError(
+                f"Git provider '{name}' type mismatch: manifest '{provider_def.provider}' "
+                f"vs instance '{live.provider}'."
+            )
+        if not live.is_configured:
+            raise ValueError(f"Git provider '{name}' is not configured in the instance.")
+        subtype_id = getattr(live, f"{provider_def.provider}_id")
+        if not subtype_id:
+            raise ValueError(f"Git provider '{name}' has no {provider_def.provider} credential.")
+        return provider_def.provider, subtype_id

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -7,6 +7,7 @@ import yaml
 from rich import print as rprint
 from rich.table import Table
 
+from dokli.apply import Applier
 from dokli.config import Config, ConnectionConfig
 from dokli.diff import build_plan
 from dokli.manifest import Manifest
@@ -81,6 +82,35 @@ def plan_command(
         details = ", ".join(item.changed) if item.changed else item.reason
         table.add_row(item.action, item.kind, item.project, item.name, details)
     rprint(table)
+
+
+def _print_apply_report(report) -> None:
+    if not report.actions:
+        rprint("[green]No changes.[/green]")
+        return
+    table = Table(title="Apply report")
+    table.add_column("Action")
+    table.add_column("Kind")
+    table.add_column("Project")
+    table.add_column("Name")
+    table.add_column("Details")
+    for action in report.actions:
+        table.add_row(action.action, action.kind, action.project, action.name, action.details)
+    rprint(table)
+
+
+@app.command(name="apply")
+def apply_command(
+    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would change without applying."),
+    deploy: bool = typer.Option(False, "--deploy", help="Deploy services after applying."),
+) -> None:
+    """Apply the manifest to a Dokploy instance (idempotent, additive)."""
+    manifest = Manifest.load(manifest_file)
+    connection = _get_connection(manifest.connection)
+    applier = Applier(manifest, connection, deploy=deploy)
+    report = applier.run(dry_run=dry_run)
+    _print_apply_report(report)
 
 
 @app.callback(no_args_is_help=True)

--- a/dokli/state.py
+++ b/dokli/state.py
@@ -86,9 +86,9 @@ class State(BaseModel):
     servers: list[LiveServer] = Field(default_factory=list)
 
 
-def collect_state(connection: ConnectionConfig) -> State:
+def collect_state(connection: ConnectionConfig, client: APIClient | None = None) -> State:
     """Collect the live state of a connection."""
-    client = APIClient(connection)
+    client = client or APIClient(connection)
     raw_projects = client.request("GET", "project.all", {}).json()
     raw_providers = client.request("GET", "gitProvider.getAll", {}).json()
     raw_servers = client.request("GET", "server.all", {}).json()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,49 @@
+"""API client tests."""
+
+from dokli.api_client import APIClient
+from dokli.config import ConnectionConfig
+
+
+def _client(mocker) -> tuple[APIClient, object]:
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    session = mocker.Mock()
+    response = mocker.Mock()
+    response.raise_for_status.return_value = None
+    session.get.return_value = response
+    client = APIClient.__new__(APIClient)
+    client.connection = connection
+    client.session = session
+    client.headers = {}
+    client.base_url = "https://example.com/api/"
+    return client, session
+
+
+class TestRequestBody:
+    """Request body handling tests."""
+
+    def test_sends_dict_body_as_json(self, mocker):
+        """We expect dict bodies to be sent as JSON."""
+        client, session = _client(mocker)
+        client.request("GET", "project.all", {"body": {"name": "x"}})
+
+        kwargs = session.get.call_args.kwargs
+        assert kwargs["json"] == {"name": "x"}
+        assert "data" not in kwargs
+
+    def test_sends_list_body_as_json(self, mocker):
+        """We expect list bodies to be sent as JSON."""
+        client, session = _client(mocker)
+        client.request("POST", "project.create", {"body": [1, 2]})
+
+        kwargs = session.post.call_args.kwargs
+        assert kwargs["json"] == [1, 2]
+        assert "data" not in kwargs
+
+    def test_sends_string_body_as_data(self, mocker):
+        """We expect raw string bodies to be sent as data."""
+        client, session = _client(mocker)
+        client.request("POST", "project.create", {"body": "raw"})
+
+        kwargs = session.post.call_args.kwargs
+        assert kwargs["data"] == "raw"
+        assert "json" not in kwargs

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,0 +1,270 @@
+"""Apply engine tests."""
+
+from dokli.apply import Applier
+from dokli.config import ConnectionConfig
+from dokli.manifest import Manifest
+from dokli.state import LiveEnvironment, LiveGitProvider, LiveProject, LiveService, State
+
+
+class FakeResponse:
+    """Minimal httpx.Response stand-in for tests."""
+
+    def __init__(self, data):
+        """Initialize with the payload to return from json()."""
+        self._data = data
+
+    def json(self):
+        """Return the canned payload."""
+        return self._data
+
+
+def _connection() -> ConnectionConfig:
+    return ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+
+
+def _compose_live(name: str, service_id: str, **overrides) -> LiveService:
+    defaults = {
+        "service_id": service_id,
+        "app_name": name,
+        "type": "compose",
+        "name": name,
+        "source_type": "raw",
+        "compose_file": "version: '3'",
+    }
+    defaults.update(overrides)
+    return LiveService(**defaults)
+
+
+def _project_live(name: str, services: list[LiveService]) -> LiveProject:
+    return LiveProject(
+        project_id=name,
+        name=name,
+        environments=[
+            LiveEnvironment(
+                environment_id="e1",
+                name="production",
+                is_default=True,
+                services=services,
+            )
+        ],
+    )
+
+
+def _provider_live(name: str, provider: str, is_configured: bool = True, **ids) -> LiveGitProvider:
+    defaults = {"git_provider_id": "gp1", "name": name, "provider": provider, "is_configured": is_configured}
+    defaults.update(ids)
+    return LiveGitProvider(**defaults)
+
+
+def _applier(mocker, state: State, responses: dict | None = None):
+    """Build an Applier with a mocked API client."""
+    client = mocker.Mock()
+    responses = responses or {}
+
+    def fake_request(method, path, params):
+        if path in responses:
+            return FakeResponse(responses[path])
+        if path == "project.create":
+            return FakeResponse({"project": {"projectId": "p-new"}, "environment": {"environmentId": "e-new"}})
+        if path == "compose.create":
+            return FakeResponse({"composeId": "c-new"})
+        if path == "application.create":
+            return FakeResponse({"applicationId": "a-new"})
+        return FakeResponse({})
+
+    client.request.side_effect = fake_request
+    mocker.patch("dokli.apply.APIClient", return_value=client)
+    mocker.patch("dokli.apply.collect_state", return_value=state)
+    return client
+
+
+class TestApplyCreate:
+    """Create flows."""
+
+    def test_dry_run_does_not_mutate(self, mocker):
+        """We expect dry-run to only record creates."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [{"name": "app", "services": [{"type": "compose", "name": "backend"}]}],
+            }
+        )
+        client = _applier(mocker, State(connection="test-env"))
+
+        report = Applier(manifest, _connection()).run(dry_run=True)
+
+        client.request.assert_not_called()
+        assert [a.action for a in report.actions] == ["create", "create"]
+
+    def test_creates_project_and_services(self, mocker):
+        """We expect create+update calls for a new project with services."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {"type": "compose", "name": "backend", "compose_file": "version: '3'"},
+                            {"type": "application", "name": "web", "image": "nginx:latest"},
+                        ],
+                    }
+                ],
+            }
+        )
+        client = _applier(mocker, State(connection="test-env"))
+
+        report = Applier(manifest, _connection()).run()
+
+        paths = [call.args[1] for call in client.request.call_args_list]
+        assert "project.create" in paths
+        assert "compose.create" in paths
+        assert "compose.update" in paths
+        assert "application.create" in paths
+        assert "application.update" in paths
+        assert [a.action for a in report.actions] == ["create", "create", "create"]
+
+
+class TestApplyUpdate:
+    """Update flows."""
+
+    def test_updates_changed_fields(self, mocker):
+        """We expect an update with only the changed fields."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [{"type": "compose", "name": "backend", "compose_file": "version: '3.8'"}],
+                    }
+                ],
+            }
+        )
+        state = State(
+            connection="test-env",
+            projects=[_project_live("app", [_compose_live("backend", "s1")])],
+        )
+        client = _applier(mocker, state)
+
+        report = Applier(manifest, _connection()).run()
+
+        update_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.update"]
+        assert len(update_calls) == 1
+        body = update_calls[0].args[2]["body"]
+        assert body["composeId"] == "s1"
+        assert "composeFile" in body
+        assert [a.action for a in report.actions] == ["update"]
+
+    def test_no_changes_skips_update(self, mocker):
+        """We expect no update when the service already matches."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [{"type": "compose", "name": "backend", "compose_file": "version: '3'"}],
+                    }
+                ],
+            }
+        )
+        state = State(
+            connection="test-env",
+            projects=[_project_live("app", [_compose_live("backend", "s1")])],
+        )
+        client = _applier(mocker, state)
+
+        report = Applier(manifest, _connection()).run()
+
+        assert [a.action for a in report.actions] == []
+        assert not any(call.args[1].endswith(".update") for call in client.request.call_args_list)
+
+
+class TestApplyGitProviders:
+    """Git provider handling."""
+
+    def test_missing_provider_skips_service(self, mocker):
+        """We expect services depending on a missing provider to be skipped."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "git_providers": [{"name": "github-main", "provider": "github"}],
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {
+                                "type": "compose",
+                                "name": "backend",
+                                "source": {"provider": "github-main", "repository": "acme/backend", "branch": "main"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        _applier(mocker, State(connection="test-env"))
+
+        report = Applier(manifest, _connection()).run()
+
+        assert any(a.action == "validate" for a in report.actions)
+        assert any(a.action == "skip" and "not configured" in a.details for a in report.actions)
+
+    def test_uses_provider_subtype_id(self, mocker):
+        """We expect the provider subtype id to be set on the service."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "git_providers": [{"name": "github-main", "provider": "github"}],
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {
+                                "type": "compose",
+                                "name": "backend",
+                                "source": {"provider": "github-main", "repository": "acme/backend", "branch": "main"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        state = State(
+            connection="test-env",
+            git_providers=[_provider_live("github-main", "github", github_id="gh-123")],
+        )
+        client = _applier(mocker, state)
+
+        Applier(manifest, _connection()).run()
+
+        update_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.update"]
+        assert update_calls
+        body = update_calls[0].args[2]["body"]
+        assert body["sourceType"] == "github"
+        assert body["githubId"] == "gh-123"
+        assert body["repository"] == "backend"
+        assert body["owner"] == "acme"
+
+
+class TestApplyDeploy:
+    """Deploy flag."""
+
+    def test_deploy_after_create(self, mocker):
+        """We expect a deploy call after creating a service."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {"name": "app", "services": [{"type": "compose", "name": "backend", "compose_file": "x: 1"}]}
+                ],
+            }
+        )
+        client = _applier(mocker, State(connection="test-env"))
+
+        Applier(manifest, _connection(), deploy=True).run()
+
+        deploy_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.deploy"]
+        assert len(deploy_calls) == 1
+        assert deploy_calls[0].args[2]["body"] == {"composeId": "c-new"}


### PR DESCRIPTION
Part of #20 — Phase 3 of Dokli as Code.

## What's in this PR

- **`dokli/apply.py`** — `Applier` engine:
  - **Additive**: never deletes resources absent from the manifest.
  - **Idempotent**: re-running apply reports *No changes* when the instance matches.
  - Projects created via `project.create` (default env returned); services created minimal (`compose.create`/`application.create`) then fully updated (`*update`), matching the API's split create/update inputs.
  - Git providers resolved by name → subtype FK (`githubId`/etc.); missing/unconfigured/type-mismatched providers produce `validate`/`skip` actions with clear messages.
  - `--deploy` flag optionally triggers `*deploy` after create/update (default: config only).
- **`dokli/state.py`** — `collect_state` accepts a reusable client.
- **`dokli/cli.py`** — `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy]`.
- **Bugfix in `dokli/api_client.py`** — dict/list bodies are now sent as **JSON** (`json=`) instead of form-encoded (`data=`). The current Dokploy API returns `415 Unsupported Media Type` for form bodies (verified live). Raw string bodies still use `data=`.

## Verified against the live instance (`dokploy.meche.lan`)

```
$ dokli apply -f apply.yaml --dry-run
create  project  dokli-demo  dokli-demo
create  compose  dokli-demo  hello

$ dokli apply -f apply.yaml
create  project  dokli-demo  dokli-demo
create  compose  dokli-demo  hello

$ dokli apply -f apply.yaml
No changes.   # ← idempotent
```

## Verification

- `make lint` ✓, `make test` → 35 passed ✓.

Next phase: **F4 `export`** (reverse instance → manifest) on `DOKLI-20-f4`.
