### PR TITLE
Dokli as Code (f4): dokli export (reverse to manifest)

### DIFF
--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -10,6 +10,7 @@ from rich.table import Table
 from dokli.apply import Applier
 from dokli.config import Config, ConnectionConfig
 from dokli.diff import build_plan
+from dokli.export import export_manifest
 from dokli.manifest import Manifest
 from dokli.openapi_cli import register_connections
 from dokli.state import collect_state
@@ -111,6 +112,26 @@ def apply_command(
     applier = Applier(manifest, connection, deploy=deploy)
     report = applier.run(dry_run=dry_run)
     _print_apply_report(report)
+
+
+@app.command(name="export")
+def export_command(
+    connection_name: str | None = typer.Argument(None, help="Connection name."),
+    output: str = typer.Option("dokploy.yaml", "--output", "-o", help="Output file, or '-' for stdout."),
+    include_secrets: bool = typer.Option(False, "--include-secrets", help="Export environment variables (secrets)."),
+) -> None:
+    """Export the live state of an instance into a manifest."""
+    connection = _get_connection(connection_name)
+    manifest, warnings = export_manifest(connection, include_secrets=include_secrets)
+    content = yaml.safe_dump(manifest.model_dump(mode="json", exclude_none=True), sort_keys=False)
+    if output == "-":
+        rprint(content)
+    else:
+        with open(output, "w") as file:
+            file.write(content)
+        rprint(f"[green]Wrote {output}[/green]")
+    for warning in warnings:
+        rprint(f"[yellow]{warning}[/yellow]")
 
 
 @app.callback(no_args_is_help=True)

--- a/dokli/export.py
+++ b/dokli/export.py
@@ -1,0 +1,147 @@
+"""Reverse-engineer a live Dokploy instance into a declarative manifest.
+
+Git provider credentials are write-only in Dokploy's API, so exported providers
+only carry metadata. The export returns warnings listing providers whose
+credentials must be re-provided (via ``token_cmd``) for ``apply`` to succeed.
+"""
+
+from dokli.config import ConnectionConfig
+from dokli.manifest import (
+    ApplicationService,
+    ComposeService,
+    GitProvider,
+    GitSource,
+    Manifest,
+    ProjectDef,
+    Service,
+)
+from dokli.state import LiveService, State, collect_state
+
+SUPPORTED_PROVIDERS: set[str] = {"github", "gitlab", "gitea", "bitbucket"}
+
+
+def export_manifest(connection: ConnectionConfig, include_secrets: bool = False) -> tuple[Manifest, list[str]]:
+    """Export a connection's live state into a manifest plus warnings.
+
+    Environment variables are considered secrets and are redacted unless
+    ``include_secrets`` is set. Git provider credentials are write-only and
+    never exported.
+    """
+    state = collect_state(connection)
+    warnings: list[str] = []
+
+    git_providers = _export_git_providers(state, warnings)
+    projects = [_export_project(project, include_secrets, warnings) for project in state.projects]
+
+    return Manifest(
+        connection=connection.name,
+        git_providers=git_providers,
+        projects=projects,
+    ), warnings
+
+
+def _export_git_providers(state: State, warnings: list[str]) -> list[GitProvider]:
+    providers = []
+    for provider in state.git_providers:
+        if provider.provider not in SUPPORTED_PROVIDERS:
+            warnings.append(
+                f"Git provider '{provider.name}': unsupported type '{provider.provider}', skipping."
+            )
+            continue
+        kwargs: dict = {
+            "name": provider.name,
+            "provider": provider.provider,  # type: ignore[arg-type]
+            "app_name": provider.app_name,
+            "owner": None,
+            "token_cmd": None,
+        }
+        if provider.url:
+            kwargs["url"] = provider.url
+        providers.append(GitProvider(**kwargs))
+        warnings.append(
+            f"Git provider '{provider.name}': credentials are write-only, "
+            "add token_cmd to the manifest so apply can resolve them."
+        )
+    return providers
+
+
+def _export_project(project, include_secrets: bool, warnings: list[str]) -> ProjectDef:
+    default_environment = next(
+        (environment for environment in project.environments if environment.is_default),
+        None,
+    )
+    services: list[Service] = []
+    if default_environment is not None:
+        services = [
+            service
+            for live in default_environment.services
+            if (service := _export_service(live, include_secrets, warnings)) is not None
+        ]
+    return ProjectDef(name=project.name, description=project.description or None, services=services)
+
+
+def _export_service(live: LiveService, include_secrets: bool, warnings: list[str]) -> Service | None:
+    if live.type == "compose":
+        return _export_compose(live, include_secrets, warnings)
+    return _export_application(live, include_secrets, warnings)
+
+
+def _redact_env(live: LiveService, include_secrets: bool, warnings: list[str]) -> str | None:
+    if not live.env:
+        return None
+    if include_secrets:
+        return live.env
+    warnings.append(
+        f"Environment variables of '{live.name}' were redacted. "
+        "Re-run with --include-secrets to export them."
+    )
+    return None
+
+
+def _export_compose(live: LiveService, include_secrets: bool, warnings: list[str]) -> ComposeService:
+    source = None
+    compose_file = None
+    compose_path = None
+    if live.source_type == "raw":
+        compose_file = live.compose_file or None
+    elif live.provider:
+        repository = _join_repository(live)
+        if repository:
+            source = GitSource(provider=live.provider, repository=repository, branch=live.branch or "main")
+            compose_path = live.compose_path
+    return ComposeService(
+        name=live.name,
+        description=live.description or None,
+        source=source,
+        compose_file=compose_file,
+        compose_path=compose_path,
+        command=live.command or None,
+        env=_redact_env(live, include_secrets, warnings),
+    )
+
+
+def _export_application(live: LiveService, include_secrets: bool, warnings: list[str]) -> ApplicationService:
+    source = None
+    image = None
+    if live.source_type == "docker":
+        image = live.docker_image
+    elif live.provider:
+        repository = _join_repository(live)
+        if repository:
+            source = GitSource(provider=live.provider, repository=repository, branch=live.branch or "main")
+    return ApplicationService(
+        name=live.name,
+        description=live.description or None,
+        source=source,
+        image=image,
+        build_type=live.build_type,
+        dockerfile_location=live.dockerfile_location,
+        build_path=live.build_path,
+        env=_redact_env(live, include_secrets, warnings),
+    )
+
+
+def _join_repository(live: LiveService) -> str:
+    if live.repository and live.owner:
+        return f"{live.owner}/{live.repository}"
+    return live.repository or ""

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,271 @@
+"""Export tests."""
+
+from dokli.export import export_manifest
+from dokli.config import ConnectionConfig
+from dokli.manifest import ApplicationService, ComposeService
+from dokli.state import LiveEnvironment, LiveGitProvider, LiveProject, LiveService, State
+
+
+def _connection() -> ConnectionConfig:
+    return ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+
+
+def _live_service(service_type: str, name: str, **overrides) -> LiveService:
+    defaults = {
+        "service_id": f"{service_type}-{name}",
+        "app_name": name,
+        "type": service_type,
+        "name": name,
+    }
+    defaults.update(overrides)
+    return LiveService(**defaults)
+
+
+def _project_live(name: str, services: list[LiveService]) -> LiveProject:
+    return LiveProject(
+        project_id=name,
+        name=name,
+        environments=[
+            LiveEnvironment(
+                environment_id="e1",
+                name="production",
+                is_default=True,
+                services=services,
+            )
+        ],
+    )
+
+
+def _provider_live(name: str, provider: str, is_configured: bool = True) -> LiveGitProvider:
+    return LiveGitProvider(
+        git_provider_id="gp1",
+        name=name,
+        provider=provider,
+        is_configured=is_configured,
+    )
+
+
+class TestExportCompose:
+    """Compose export tests."""
+
+    def test_raw_compose(self, mocker):
+        """We expect a raw compose to be exported with its file inline."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [_live_service("compose", "backend", source_type="raw", compose_file="version: '3'")],
+                    )
+                ],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection())
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, ComposeService)
+        assert service.compose_file == "version: '3'"
+        assert service.source is None
+        assert warnings == []
+
+    def test_git_compose(self, mocker):
+        """We expect a git compose to be exported as a source."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [
+                            _live_service(
+                                "compose",
+                                "backend",
+                                source_type="github",
+                                provider="github-main",
+                                repository="backend",
+                                owner="acme",
+                                branch="main",
+                                compose_path="docker-compose.yml",
+                            )
+                        ],
+                    )
+                ],
+            ),
+        )
+
+        manifest, _ = export_manifest(_connection())
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, ComposeService)
+        assert service.source is not None
+        assert service.source.provider == "github-main"
+        assert service.source.repository == "acme/backend"
+        assert service.source.branch == "main"
+        assert service.compose_path == "docker-compose.yml"
+
+
+class TestExportSecrets:
+    """Secret redaction tests."""
+
+    def test_env_redacted_by_default(self, mocker):
+        """We expect env vars to be redacted unless explicitly requested."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [
+                            _live_service(
+                                "compose",
+                                "backend",
+                                source_type="raw",
+                                compose_file="version: '3'",
+                                env="PASSWORD=hunter2",
+                            )
+                        ],
+                    )
+                ],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection())
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, ComposeService)
+        assert service.env is None
+        assert any("redacted" in warning for warning in warnings)
+
+    def test_env_exported_with_include_secrets(self, mocker):
+        """We expect env vars to be exported with include_secrets."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [
+                            _live_service(
+                                "compose",
+                                "backend",
+                                source_type="raw",
+                                compose_file="version: '3'",
+                                env="PASSWORD=hunter2",
+                            )
+                        ],
+                    )
+                ],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection(), include_secrets=True)
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, ComposeService)
+        assert service.env == "PASSWORD=hunter2"
+        assert not any("redacted" in warning for warning in warnings)
+
+
+class TestExportApplication:
+    """Application export tests."""
+
+    def test_docker_application(self, mocker):
+        """We expect a docker application to be exported with its image."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [_live_service("application", "web", source_type="docker", docker_image="nginx:latest")],
+                    )
+                ],
+            ),
+        )
+
+        manifest, _ = export_manifest(_connection())
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, ApplicationService)
+        assert service.image == "nginx:latest"
+        assert service.source is None
+
+    def test_git_application(self, mocker):
+        """We expect a git application to be exported with build details."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [
+                            _live_service(
+                                "application",
+                                "web",
+                                source_type="github",
+                                provider="github-main",
+                                repository="web",
+                                owner="acme",
+                                branch="main",
+                                build_type="dockerfile",
+                                dockerfile_location="./web/Dockerfile",
+                            )
+                        ],
+                    )
+                ],
+            ),
+        )
+
+        manifest, _ = export_manifest(_connection())
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, ApplicationService)
+        assert service.source.repository == "acme/web"
+        assert service.build_type == "dockerfile"
+        assert service.dockerfile_location == "./web/Dockerfile"
+
+
+class TestExportGitProviders:
+    """Git provider export tests."""
+
+    def test_provider_metadata_with_warning(self, mocker):
+        """We expect provider metadata without credentials plus a warning."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                git_providers=[_provider_live("github-main", "github")],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection())
+
+        assert len(manifest.git_providers) == 1
+        provider = manifest.git_providers[0]
+        assert provider.name == "github-main"
+        assert provider.provider == "github"
+        assert provider.token_cmd is None
+        assert any("write-only" in warning for warning in warnings)
+
+    def test_unsupported_provider_skipped(self, mocker):
+        """We expect unsupported provider types to be skipped with a warning."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                git_providers=[_provider_live("custom", "git")],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection())
+
+        assert manifest.git_providers == []
+        assert any("unsupported type" in warning for warning in warnings)


### PR DESCRIPTION
Part of #20 — Phase 4 of Dokli as Code.

## What's in this PR

- **`dokli/export.py`** — reverse-engineer a live instance into a declarative manifest:
  - Projects → services (from the default environment)
  - Raw compose services → `compose_file` inline
  - Git-based compose/application services → `source` (provider name + `owner/repository` + branch) + `compose_path`/build details
  - Docker applications → `image`
- **Secret handling** (default):
  - **`env` variables are redacted** unless `--include-secrets`; a warning lists each redacted service
  - Git provider **credentials are write-only** in Dokploy's API → metadata only + warning to add `token_cmd`
  - Unsupported provider types are skipped with a warning
- **`dokli export [connection] [-o file] [--include-secrets]`** command.

## Verified against the live instance (`dokploy.meche.lan`)

Exported the full instance (media, services, data, laboratory, cloud, AI Tools) as YAML. `env:` fields are redacted with per-service warnings; git provider exported as metadata with a credential warning.

## Verification

- `make lint` ✓, `make test` → 43 passed ✓.

Note: `compose_file` is exported as-is, so hardcoded values in compose definitions (e.g. a grafana admin password) are still present — review before committing exported manifests.

Next phase: **F5 `init` + README + close #20** on `DOKLI-20-f5`.
