### PR TITLE
Dokli as Code (f5): dokli init + docs (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,61 @@ $ dokli api test-env project one --format json zuanf1SWHMFO11y6xqpRR
 "redis": [], "compose": []}
 ```
 
+## Dokli as Code
+
+Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokploy. A manifest file (`dokploy.yaml`) describes the desired state and `dokli apply` brings the instance to match it — idempotent and additive (it never deletes resources that are not in the manifest).
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `dokli init` | Scaffold a new manifest. |
+| `dokli state [connection]` | Show the current state of an instance. |
+| `dokli plan [-f dokploy.yaml]` | Preview what would change. |
+| `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy]` | Configure the instance to match the manifest. `--dry-run` only previews; `--deploy` also triggers deployments. |
+| `dokli export [connection] [-o file] [--include-secrets]` | Reverse-engineer a live instance into a manifest. |
+
+### Manifest
+
+```yaml
+# dokploy.yaml
+connection: prod
+
+git_providers:
+  - name: github-main
+    provider: github
+    token_cmd: "secret-tool lookup dokli github-main"
+
+projects:
+  - name: myapp
+    services:
+      - type: compose
+        name: backend
+        source:
+          provider: github-main
+          repository: jonykalavera/backend
+          branch: main
+        compose_path: docker-compose.yml
+      - type: application
+        name: web
+        image: nginx:latest
+        env: |
+          NODE_ENV=production
+```
+
+- Services live in the project's **default environment** (Dokploy creates one per project).
+- `compose_file` accepts raw compose YAML or a path to a local file (mutually exclusive with `source`).
+- **Secrets are never stored in the manifest.** Git provider credentials are write-only in Dokploy's API; reference them with `token_cmd` (same pattern as `api_key_cmd`). `export` redacts service environment variables by default (`--include-secrets` to include them) and reports which providers need credentials.
+
+### Workflow
+
+```bash
+dokli export meche -o dokploy.yaml   # capture an existing instance
+dokli plan                           # preview changes
+dokli apply --dry-run                # dry run
+dokli apply                          # configure the instance
+```
+
 ## TUI
 
 Still a WIP. Basic functionality will be implemented at 0.2.0 release.

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -11,6 +11,7 @@ from dokli.apply import Applier
 from dokli.config import Config, ConnectionConfig
 from dokli.diff import build_plan
 from dokli.export import export_manifest
+from dokli.init import init_manifest
 from dokli.manifest import Manifest
 from dokli.openapi_cli import register_connections
 from dokli.state import collect_state
@@ -51,6 +52,19 @@ def _get_connection(connection_name: str | None) -> ConnectionConfig:
     if len(config.connections) == 1:
         return config.connections[0]
     raise typer.BadParameter("Specify a connection name.")
+
+
+@app.command(name="init")
+def init_command(
+    output: str = typer.Option("dokploy.yaml", "--output", "-o", help="Output file."),
+) -> None:
+    """Scaffold a new dokli manifest."""
+    try:
+        path = init_manifest(state["config"], output)
+    except FileExistsError as err:
+        rprint(f"[red]{err}[/red]")
+        raise typer.Exit(code=1) from None
+    rprint(f"[green]Wrote {path}[/green]")
 
 
 @app.command(name="state")

--- a/dokli/init.py
+++ b/dokli/init.py
@@ -1,0 +1,44 @@
+"""Manifest scaffolding."""
+
+from pathlib import Path
+
+from dokli.config import Config
+
+TEMPLATE = """\
+# Dokli as Code manifest.
+#
+# Describes the desired state of a Dokploy instance. Apply it with:
+#   dokli apply            # configure the instance to match this file
+#   dokli plan             # preview changes first
+#
+# connection: name of a connection defined in your dokli config.
+
+connection: {connection}
+
+# Git providers are referenced by services. Credentials are write-only in
+# Dokploy's API, so configure providers in the instance and resolve the
+# credential at apply time via token_cmd (or DOKLI_* env vars).
+#
+# git_providers:
+#   - name: github-main
+#     provider: github
+#     url: https://github.com
+#     app_name: dokli
+#     token_cmd: "secret-tool lookup dokli github-main"
+
+projects: []
+"""
+
+
+def init_manifest(config: Config, output: str = "dokploy.yaml") -> str:
+    """Write a manifest template to ``output`` and return its path.
+
+    Raises:
+        FileExistsError: If the output file already exists.
+    """
+    path = Path(output)
+    if path.exists():
+        raise FileExistsError(f"{output} already exists.")
+    connection = config.connections[0].name if config.connections else "<connection-name>"
+    path.write_text(TEMPLATE.format(connection=connection))
+    return str(path)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,41 @@
+"""Init tests."""
+
+import pytest
+
+from dokli.config import Config
+from dokli.init import init_manifest
+
+
+class TestInitManifest:
+    """Manifest scaffolding tests."""
+
+    def test_writes_template(self, tmp_path):
+        """We expect a manifest template to be written."""
+        config = Config(connections=[])
+        output = str(tmp_path / "dokploy.yaml")
+
+        path = init_manifest(config, output)
+
+        content = open(path).read()
+        assert "connection: <connection-name>" in content
+        assert "projects: []" in content
+
+    def test_uses_first_connection(self, tmp_path):
+        """We expect the first connection name to be used."""
+        config = Config.model_validate(
+            {"connections": [{"name": "prod", "url": "https://example.com", "api_key_cmd": "echo key"}]}
+        )
+        output = str(tmp_path / "dokploy.yaml")
+
+        init_manifest(config, output)
+
+        assert "connection: prod" in open(output).read()
+
+    def test_refuses_to_overwrite(self, tmp_path):
+        """We expect an error when the output file already exists."""
+        config = Config(connections=[])
+        output = str(tmp_path / "dokploy.yaml")
+        open(output, "w").write("existing")
+
+        with pytest.raises(FileExistsError):
+            init_manifest(config, output)


### PR DESCRIPTION
Closes #20

Final phase of Dokli as Code.

## What's in this PR

- **`dokli/init.py`** + `dokli init [-o dokploy.yaml]` — scaffold a new manifest (refuses to overwrite, pre-fills the first configured connection name).
- **README** — new "Dokli as Code" section documenting the manifest format, the five commands (`init`, `state`, `plan`, `apply`, `export`) and the secret-handling model.

## Complete feature (all phases merged/open)

- F1: manifest models + `dokli state`
- F2: `dokli plan`
- F3: `dokli apply` (idempotent, additive)
- F4: `dokli export` (reverse, secrets redacted)
- F5: `dokli init` + docs

## Verification

- `make lint` ✓, `make test` → 46 passed ✓
- `dokli init` smoke-tested (template written, connection pre-filled)
- `dokli --help` shows all five as-code commands

Note: the `dokli-demo` test project was removed from the `dokploy.meche.lan` instance during this work.
