### PR TITLE
Add dokli refresh to refetch the cached OpenAPI schema

### DIFF
--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -7,6 +7,7 @@ import yaml
 from rich import print as rprint
 from rich.table import Table
 
+from dokli.api_client import APIClient
 from dokli.apply import Applier
 from dokli.config import Config, ConnectionConfig
 from dokli.diff import build_plan
@@ -65,6 +66,14 @@ def init_command(
         rprint(f"[red]{err}[/red]")
         raise typer.Exit(code=1) from None
     rprint(f"[green]Wrote {path}[/green]")
+
+
+@app.command(name="refresh")
+def refresh_command(connection_name: str | None = typer.Argument(None, help="Connection name.")) -> None:
+    """Refetch and refresh the cached OpenAPI schema for a connection."""
+    connection = _get_connection(connection_name)
+    APIClient(connection, force_refresh=True)
+    rprint(f"[green]Refreshed OpenAPI schema for {connection.name}.[/green]")
 
 
 @app.command(name="state")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Dokli CLI tests."""
 
-from dokli.cli import app, main
+from dokli.cli import app, main, refresh_command
+from dokli.config import ConnectionConfig
 
 
 def test_loads_api_commands(mocker):
@@ -13,7 +14,23 @@ def test_loads_tui_command():
     assert "tui" in [cmd.name for cmd in app.registered_commands]
 
 
+def test_loads_refresh_command():
+    """We expect the CLI to load the refresh command."""
+    assert "refresh" in [cmd.name for cmd in app.registered_commands]
+
+
 def test_app_has_main_callback():
     """We expect the CLI to have a main callback."""
     assert app.registered_callback.callback is main
     assert app.registered_callback.no_args_is_help
+
+
+def test_refresh_command_forces_refresh(mocker):
+    """We expect refresh to force the schema refresh."""
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    mocker.patch("dokli.cli._get_connection", return_value=connection)
+    client = mocker.patch("dokli.cli.APIClient")
+
+    refresh_command("test-env")
+
+    client.assert_called_once_with(connection, force_refresh=True)


### PR DESCRIPTION
Closes #18

Adds `dokli refresh <connection>` to force-refetch and rewrite the cached OpenAPI schema for a connection (the `APIClient` already supported `force_refresh`; it was just not exposed).

Verified against `dokploy.meche.lan` — the cache file is rewritten and connectivity is validated.

- `make lint` ✓, `make test` → 48 passed ✓
