### PR TITLE
Redact secrets in API and state output (--show-secrets opt-in)

### DIFF
--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -11,6 +11,7 @@ from dokli.apply import Applier
 from dokli.config import Config, ConnectionConfig
 from dokli.diff import build_plan
 from dokli.export import export_manifest
+from dokli.formatting import redact_secrets
 from dokli.init import init_manifest
 from dokli.manifest import Manifest
 from dokli.openapi_cli import register_connections
@@ -68,11 +69,17 @@ def init_command(
 
 
 @app.command(name="state")
-def state_command(connection_name: str | None = typer.Argument(None, help="Connection name.")) -> None:
+def state_command(
+    connection_name: str | None = typer.Argument(None, help="Connection name."),
+    show_secrets: bool = typer.Option(False, "--show-secrets", help="Show environment variables (secrets)."),
+) -> None:
     """Show the current state of a Dokploy instance."""
     connection = _get_connection(connection_name)
     live_state = collect_state(connection)
-    rprint(yaml.dump(live_state.model_dump(mode="json")))
+    data = live_state.model_dump(mode="json")
+    if not show_secrets:
+        data = redact_secrets(data)
+    rprint(yaml.dump(data))
 
 
 @app.command(name="plan")

--- a/dokli/formatting.py
+++ b/dokli/formatting.py
@@ -1,8 +1,9 @@
 """Dokli formatting utility functions."""
 
 import json
+import re
 from enum import Enum
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import typer
 import yaml
@@ -10,6 +11,12 @@ from httpx import Response
 from rich.table import Table
 
 app = typer.Typer()
+
+SECRET_KEY_PATTERN = re.compile(
+    r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|access[_-]?key)"
+)
+
+D = TypeVar("D")
 
 
 class Format(str, Enum):
@@ -21,16 +28,51 @@ class Format(str, Enum):
     table = "table"
 
 
-def format_response(response: Response, format: Format) -> str | Table | dict | list:
+def format_response(response: Response, format: Format, show_secrets: bool = False) -> str | Table | dict | list:
     """Format the given Response in the given format."""
     raw_data = response.text
     if not raw_data:
         return ""
     data = json.loads(raw_data)
+    if not show_secrets:
+        data = redact_secrets(data)
     return format_data(data, format)
 
 
-D = TypeVar("D")
+def redact_secrets(data: Any) -> Any:
+    """Recursively replace values of secret-like keys with ``***``.
+
+    Keys matching ``password``, ``secret``, ``token``, ``api_key``,
+    ``private_key`` or ``access_key`` are redacted. The ``env`` field is
+    handled specially: only the values of secret-like variables are redacted.
+    """
+    match data:
+        case dict():
+            redacted = {}
+            for key, value in data.items():
+                if SECRET_KEY_PATTERN.search(str(key)):
+                    redacted[key] = "***" if value is not None else None
+                elif str(key) == "env" and isinstance(value, str):
+                    redacted[key] = _redact_env_lines(value)
+                else:
+                    redacted[key] = redact_secrets(value)
+            return redacted
+        case list():
+            return [redact_secrets(item) for item in data]
+        case _:
+            return data
+
+
+def _redact_env_lines(value: str) -> str:
+    lines = []
+    for line in value.splitlines():
+        if "=" in line:
+            key, _, _ = line.partition("=")
+            if SECRET_KEY_PATTERN.search(key):
+                lines.append(f"{key}=***")
+                continue
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def format_data(data: D, format: Format) -> str | D | Table:

--- a/dokli/openapi_cli.py
+++ b/dokli/openapi_cli.py
@@ -63,10 +63,19 @@ def _api_command_factory(connection, route, method="GET", params=None, request_b
         )
     # add format parameter
     parameters.append(Parameter("format", Parameter.KEYWORD_ONLY, default=Format.yaml, annotation=Format))
+    # add secrets parameter
+    parameters.append(
+        Parameter(
+            "show_secrets",
+            Parameter.KEYWORD_ONLY,
+            default=False,
+            annotation=bool,
+        )
+    )
     # Create a Signature object
     sig = Signature(parameters)
 
-    def api_command(format=Format.json, **kwargs):
+    def api_command(format=Format.json, show_secrets=False, **kwargs):
         params = {original_name.get(x, x): v for x, v in kwargs.items()}
         response = run_command(
             connection=connection,
@@ -77,7 +86,7 @@ def _api_command_factory(connection, route, method="GET", params=None, request_b
         )
         match response:
             case Response():
-                rprint(format_response(response, format=format))
+                rprint(format_response(response, format=format, show_secrets=show_secrets))
             case HTTPError():
                 rprint(f"[red]{response}[/red]")
                 raise typer.Exit(code=1)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,35 @@
+"""Formatting/redaction tests."""
+
+from dokli.formatting import redact_secrets
+
+
+class TestRedactSecrets:
+    """Secret redaction tests."""
+
+    def test_redacts_secret_keys(self):
+        """We expect secret-like keys to be redacted."""
+        data = {"name": "myapp", "databasePassword": "hunter2", "refreshToken": "abc"}
+        redacted = redact_secrets(data)
+        assert redacted["databasePassword"] == "***"
+        assert redacted["refreshToken"] == "***"
+        assert redacted["name"] == "myapp"
+
+    def test_keeps_none_values(self):
+        """We expect None values to stay None."""
+        assert redact_secrets({"password": None}) == {"password": None}
+
+    def test_redacts_nested_lists(self):
+        """We expect redaction to recurse into lists."""
+        data = {"items": [{"token": "x"}, {"name": "ok"}]}
+        assert redact_secrets(data) == {"items": [{"token": "***"}, {"name": "ok"}]}
+
+    def test_redacts_env_variables(self):
+        """We expect secret-like variables in env to be redacted by value."""
+        data = {"env": "NODE_ENV=production\nDB_PASSWORD=hunter2\nAPI_KEY=abc123"}
+        redacted = redact_secrets(data)
+        assert redacted["env"] == "NODE_ENV=production\nDB_PASSWORD=***\nAPI_KEY=***"
+
+    def test_unrelated_fields_untouched(self):
+        """We expect unrelated fields to pass through unchanged."""
+        data = {"projectId": "p1", "name": "app", "services": []}
+        assert redact_secrets(data) == data


### PR DESCRIPTION
Closes #3

## What's in this PR

- **`dokli/formatting.py`** — `redact_secrets()`: recursively replaces values of secret-like keys (`password`, `secret`, `token`, `api_key`, `private_key`, `access_key`) with `***`. The `env` field is handled per-variable (only secret-like variables are redacted).
- **`dokli/openapi_cli.py`** — generated `api` commands gain a `--show-secrets` flag (hidden by default), so e.g. `dokli api meche redis all` no longer leaks `databasePassword`.
- **`dokli/cli.py`** — `dokli state` gains the same `--show-secrets` flag (redacts service env by default, consistent with `export`).

## Verified against `dokploy.meche.lan`

- Default: `env: FRIGATE_RTSP_PASSWORD=***` / `MYSQL_PASSWORD=***`
- `--show-secrets`: real values shown.

## Verification

- `make lint` ✓, `make test` → 51 passed ✓
