### PR TITLE
Release pipeline: publish dokli 0.1.0 to PyPI + GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+    - name: Check version matches tag
+      run: |
+        version=$(grep -E '^version = ' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
+        tag="${GITHUB_REF_NAME#v}"
+        if [ "$version" != "$tag" ]; then
+          echo "pyproject version $version does not match tag $tag" >&2
+          exit 1
+        fi
+    - name: Build
+      run: uv build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        username: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+        packages-dir: dist/
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,8 @@ dev-tui:
 
 def-tui-console:
 	uv run textual console - SYSTEM -X EVENT
+
+release:
+	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=0.1.0" && exit 1)
+	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
+	git push origin "v$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ A magical CLI/TUI for interacting with [Dokploy](https://github.com/Dokploy/dokp
 ## Installation
 
 ```bash
-pip install git+https://github.com/jonykalavera/dokli.git
+pip install dokli
 # with TUI support
+pip install "dokli[tui]"
+# latest from git
+pip install git+https://github.com/jonykalavera/dokli.git
+# with TUI support from git
 pip install git+https://github.com/jonykalavera/dokli.git#egg=dokli[tui]
 ```
 
@@ -213,6 +217,16 @@ Still a WIP. Basic functionality will be implemented at 0.2.0 release.
 The CLI is designed to keep up with any changes in the API. Commands are dynamically inferred from the OpenAPI spec.
 I did this because I want to do some test automation and the official CLI seems incomplete at the moment. The TUI is because I am into tools like [yazi](https://yazi-rs.github.io/), [lazygit](https://github.com/jesseduffield/lazygit), [k9s](https://k9scli.io/), [dry](https://github.com/moncho/dry), etc. I like to keep my terminal open at all times `$`.
 Also, it seemed to me like something cool to do this weekend. I learned a bunch about [texual](https://textual.textualize.io/), [typer](https://github.com/tiangolo/typer) and [Dokploy](https://github.com/Dokploy/dokploy).
+
+## Release
+
+Releases are automated via GitHub Actions (`.github/workflows/release.yml`): pushing a `v*` tag builds the package with `uv build`, publishes it to PyPI, and creates a GitHub Release.
+
+```bash
+make release VERSION=0.1.0
+```
+
+This requires a PyPI API token in the repository secrets as `PYPI_TOKEN`. The version in `pyproject.toml` must match the tag.
 
 ## Buy me a 🌮
 


### PR DESCRIPTION
Closes #10

## What's in this PR

- **`.github/workflows/release.yml`** — on `v*` tag push:
  1. Verifies the tag matches the version in `pyproject.toml`
  2. Builds the package (`uv build`)
  3. Publishes to **PyPI** (`pypa/gh-action-pypi-publish`, `PYPI_TOKEN` secret)
  4. Creates a **GitHub Release** with auto-generated notes
- **`Makefile`** — `make release VERSION=x.y.z` (tags + pushes `v*`).
- **README** — install via `pip install dokli` and a Release section.

## Verified

- `uv build` produces `dokli-0.1.0.tar.gz` + wheel ✓
- Wheel installs cleanly in a fresh venv and the CLI works (all commands incl. as-code) ✓
- `make lint` ✓, `make test` → 53 passed ✓

## Required action from you

Add a **PyPI API token** to the repo secrets as **`PYPI_TOKEN`** (Settings → Secrets and variables → Actions). Then releasing is just `make release VERSION=0.1.0`.
