### PR TITLE
Fix PyPI publish input in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        username: __token__
+        user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
         packages-dir: dist/
     - name: Create GitHub Release


### PR DESCRIPTION
The release workflow failed at the publish step: `pypa/gh-action-pypi-publish` expects `user` (not `username`). One-line fix; nothing was published yet. After merging I'll re-tag `v0.1.0` to trigger the release.