### PR TITLE
Release workflow: use PyPI trusted publishing (OIDC) + skip-existing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -28,10 +29,10 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
         packages-dir: dist/
+        skip-existing: true
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
+        draft: false
         generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -220,13 +220,13 @@ Also, it seemed to me like something cool to do this weekend. I learned a bunch 
 
 ## Release
 
-Releases are automated via GitHub Actions (`.github/workflows/release.yml`): pushing a `v*` tag builds the package with `uv build`, publishes it to PyPI, and creates a GitHub Release.
+Releases are automated via GitHub Actions (`.github/workflows/release.yml`): pushing a `v*` tag builds the package with `uv build`, publishes it to PyPI via **trusted publishing** (OIDC), and creates a GitHub Release.
 
 ```bash
 make release VERSION=0.1.0
 ```
 
-This requires a PyPI API token in the repository secrets as `PYPI_TOKEN`. The version in `pyproject.toml` must match the tag.
+This requires the repo to be configured as a trusted publisher on PyPI (no API token needed). The version in `pyproject.toml` must match the tag.
 
 ## Buy me a 🌮
 


### PR DESCRIPTION
Now that the repo is a trusted publisher on PyPI, the release workflow no longer needs a `PYPI_TOKEN` secret:

- Adds `id-token: write` permission (OIDC) and drops the token inputs from `pypa/gh-action-pypi-publish`
- Adds `skip-existing: true` so re-running a tag doesn't fail with `400 Bad Request`
- Sets `draft: false` explicitly on the GitHub Release step

Release status: **dokli 0.1.0 is live on PyPI** (published by the first run) and the GitHub Release v0.1.0 is published (Latest).