### PR TITLE
Dokli as Code v2 (f1): database services

### DIFF
--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -5,6 +5,8 @@ created with the minimal payload the API requires, then fully updated to the
 desired state (the API splits ``create`` and ``update`` inputs).
 """
 
+import secrets
+import subprocess
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -12,7 +14,7 @@ from pydantic import BaseModel, Field
 from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.diff import resolve_compose_file
-from dokli.manifest import ApplicationService, ComposeService, Manifest, Service
+from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Service
 from dokli.state import LiveGitProvider, LiveProject, LiveService, collect_state
 
 
@@ -20,7 +22,17 @@ class ApplyAction(BaseModel):
     """A single apply action."""
 
     action: Literal["create", "update", "validate", "skip"]
-    kind: Literal["project", "compose", "application", "git_provider"]
+    kind: Literal[
+        "project",
+        "compose",
+        "application",
+        "postgres",
+        "mysql",
+        "mariadb",
+        "mongo",
+        "redis",
+        "git_provider",
+    ]
     project: str = ""
     name: str
     details: str = ""
@@ -30,6 +42,7 @@ class ApplyReport(BaseModel):
     """Report of what apply did or would do."""
 
     actions: list[ApplyAction] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
 
 
 class Applier:
@@ -150,8 +163,10 @@ class Applier:
         try:
             if isinstance(service_def, ComposeService):
                 service_id = self._create_compose(service_def, environment_id)
-            else:
+            elif isinstance(service_def, ApplicationService):
                 service_id = self._create_application(service_def, environment_id)
+            else:
+                service_id = self._create_database(service_def, environment_id)
             payload = self._service_desired_payload(service_def, None)
             self._apply_update(service_def.type, service_id, payload)
         except ValueError as err:
@@ -228,22 +243,56 @@ class Applier:
         response = self.client.request("POST", "application.create", {"body": payload}).json()
         return response["applicationId"]
 
+    def _create_database(self, service_def: DatabaseService, environment_id: str) -> str:
+        password = self._resolve_database_password(service_def)
+        payload: dict[str, Any] = {
+            "name": service_def.name,
+            "environmentId": environment_id,
+            "databasePassword": password,
+        }
+        if service_def.type != "redis":
+            payload["databaseUser"] = service_def.database_user or service_def.name
+        if service_def.type in ("postgres", "mysql", "mariadb"):
+            payload["databaseName"] = service_def.database_name or service_def.name
+        if service_def.description:
+            payload["description"] = service_def.description
+        if service_def.image:
+            payload["dockerImage"] = service_def.image
+        response = self.client.request("POST", f"{service_def.type}.create", {"body": payload}).json()
+        return response[f"{service_def.type}Id"]
+
+    def _resolve_database_password(self, service_def: DatabaseService) -> str:
+        """Resolve a database password from the manifest (or generate one)."""
+        if service_def.password:
+            return service_def.password
+        if service_def.password_cmd:
+            output = subprocess.check_output(service_def.password_cmd.split())
+            return output.decode("utf-8").strip()
+        generated = secrets.token_urlsafe(24)
+        self.report.warnings.append(
+            f"Database '{service_def.name}': no password/password_cmd set, "
+            f"generated a random password (not stored): {generated}"
+        )
+        return generated
+
     def _apply_update(self, service_type: str, service_id: str, payload: dict[str, Any]) -> None:
         if not payload:
             return
-        id_field = {"compose": "composeId", "application": "applicationId"}[service_type]
+        id_field = f"{service_type}Id"
         payload[id_field] = service_id
         self.client.request("POST", f"{service_type}.update", {"body": payload})
 
     def _deploy(self, service_type: str, service_id: str) -> None:
-        id_field = {"compose": "composeId", "application": "applicationId"}[service_type]
+        id_field = f"{service_type}Id"
         self.client.request("POST", f"{service_type}.deploy", {"body": {id_field: service_id}})
 
     def _service_desired_payload(self, service_def: Service, live: LiveService | None) -> dict[str, Any]:
         """Return the desired fields for a service, skipping fields that already match."""
         if isinstance(service_def, ComposeService):
             return self._compose_payload(service_def, live)
-        return self._application_payload(service_def, live)
+        if isinstance(service_def, ApplicationService):
+            return self._application_payload(service_def, live)
+        return self._database_payload(service_def, live)
 
     def _compose_payload(self, service_def: ComposeService, live: LiveService | None) -> dict[str, Any]:
         payload: dict[str, Any] = {}
@@ -305,6 +354,30 @@ class Applier:
             payload["dockerfileLocation"] = service_def.dockerfile_location
         if service_def.build_path and (live is None or live.build_path != service_def.build_path):
             payload["buildPath"] = service_def.build_path
+        if service_def.env is not None and (live is None or (live.env or "") != service_def.env):
+            payload["env"] = service_def.env
+        return payload
+
+    def _database_payload(self, service_def: DatabaseService, live: LiveService | None) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if service_def.description is not None and (
+            live is None or (live.description or "") != service_def.description
+        ):
+            payload["description"] = service_def.description
+        if service_def.image and (live is None or live.docker_image != service_def.image):
+            payload["dockerImage"] = service_def.image
+        if service_def.type in ("postgres", "mysql", "mariadb"):
+            database_name = service_def.database_name or service_def.name
+            if live is None or live.database_name != database_name:
+                payload["databaseName"] = database_name
+        if service_def.type != "redis":
+            database_user = service_def.database_user or service_def.name
+            if live is None or live.database_user != database_user:
+                payload["databaseUser"] = database_user
+        if service_def.password or service_def.password_cmd:
+            password = self._resolve_database_password(service_def)
+            if live is None or live.database_password != password:
+                payload["databasePassword"] = password
         if service_def.env is not None and (live is None or (live.env or "") != service_def.env):
             payload["env"] = service_def.env
         return payload

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -118,16 +118,18 @@ def plan_command(
 def _print_apply_report(report) -> None:
     if not report.actions:
         rprint("[green]No changes.[/green]")
-        return
-    table = Table(title="Apply report")
-    table.add_column("Action")
-    table.add_column("Kind")
-    table.add_column("Project")
-    table.add_column("Name")
-    table.add_column("Details")
-    for action in report.actions:
-        table.add_row(action.action, action.kind, action.project, action.name, action.details)
-    rprint(table)
+    else:
+        table = Table(title="Apply report")
+        table.add_column("Action")
+        table.add_column("Kind")
+        table.add_column("Project")
+        table.add_column("Name")
+        table.add_column("Details")
+        for action in report.actions:
+            table.add_row(action.action, action.kind, action.project, action.name, action.details)
+        rprint(table)
+    for warning in report.warnings:
+        rprint(f"[yellow]{warning}[/yellow]")
 
 
 @app.command(name="apply")

--- a/dokli/diff.py
+++ b/dokli/diff.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from dokli.manifest import ApplicationService, ComposeService, GitSource, Manifest, Service
+from dokli.manifest import ApplicationService, ComposeService, DatabaseService, GitSource, Manifest, Service
 from dokli.state import LiveEnvironment, LiveProject, LiveService, State
 
 
@@ -13,7 +13,17 @@ class PlanItem(BaseModel):
     """A single planned change."""
 
     action: Literal["create", "update", "validate"]
-    kind: Literal["project", "compose", "application", "git_provider"]
+    kind: Literal[
+        "project",
+        "compose",
+        "application",
+        "postgres",
+        "mysql",
+        "mariadb",
+        "mongo",
+        "redis",
+        "git_provider",
+    ]
     project: str = ""
     name: str
     changed: list[str] = Field(default_factory=list)
@@ -140,8 +150,10 @@ def _service_changes(service_def: Service, live: LiveService) -> list[str]:
     changes: list[str] = []
     if isinstance(service_def, ComposeService):
         _compose_changes(service_def, live, changes)
-    else:
+    elif isinstance(service_def, ApplicationService):
         _application_changes(service_def, live, changes)
+    else:
+        _database_changes(service_def, live, changes)
     return changes
 
 
@@ -176,6 +188,21 @@ def _application_changes(service_def: ApplicationService, live: LiveService, cha
         changes.append("dockerfile_location")
     if service_def.build_path and live.build_path != service_def.build_path:
         changes.append("build_path")
+    if service_def.env is not None and (live.env or "") != service_def.env:
+        changes.append("env")
+
+
+def _database_changes(service_def: DatabaseService, live: LiveService, changes: list[str]) -> None:
+    if service_def.description is not None and (live.description or "") != service_def.description:
+        changes.append("description")
+    if service_def.image and live.docker_image != service_def.image:
+        changes.append("image")
+    if service_def.database_name and live.database_name != service_def.database_name:
+        changes.append("database_name")
+    if service_def.database_user and live.database_user != service_def.database_user:
+        changes.append("database_user")
+    if service_def.password and live.database_password != service_def.password:
+        changes.append("password")
     if service_def.env is not None and (live.env or "") != service_def.env:
         changes.append("env")
 

--- a/dokli/export.py
+++ b/dokli/export.py
@@ -9,6 +9,7 @@ from dokli.config import ConnectionConfig
 from dokli.manifest import (
     ApplicationService,
     ComposeService,
+    DatabaseService,
     GitProvider,
     GitSource,
     Manifest,
@@ -83,7 +84,9 @@ def _export_project(project, include_secrets: bool, warnings: list[str]) -> Proj
 def _export_service(live: LiveService, include_secrets: bool, warnings: list[str]) -> Service | None:
     if live.type == "compose":
         return _export_compose(live, include_secrets, warnings)
-    return _export_application(live, include_secrets, warnings)
+    if live.type == "application":
+        return _export_application(live, include_secrets, warnings)
+    return _export_database(live, include_secrets, warnings)
 
 
 def _redact_env(live: LiveService, include_secrets: bool, warnings: list[str]) -> str | None:
@@ -137,6 +140,25 @@ def _export_application(live: LiveService, include_secrets: bool, warnings: list
         build_type=live.build_type,
         dockerfile_location=live.dockerfile_location,
         build_path=live.build_path,
+        env=_redact_env(live, include_secrets, warnings),
+    )
+
+
+def _export_database(live: LiveService, include_secrets: bool, warnings: list[str]) -> DatabaseService:
+    if live.database_password:
+        warnings.append(
+            f"Database password of '{live.name}' was not exported. "
+            "Set password or password_cmd in the manifest for apply."
+        )
+    return DatabaseService(
+        type=live.type,  # type: ignore[arg-type]
+        name=live.name,
+        description=live.description or None,
+        image=live.docker_image,
+        database_name=live.database_name,
+        database_user=live.database_user,
+        password=None,
+        password_cmd=None,
         env=_redact_env(live, include_secrets, warnings),
     )
 

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -79,7 +79,30 @@ class ApplicationService(BaseModel):
     env: str | None = Field(default=None, description="Environment variables as KEY=VALUE lines.")
 
 
-Service = Annotated[ComposeService | ApplicationService, Field(discriminator="type")]
+class DatabaseService(BaseModel):
+    """A database service."""
+
+    type: Literal["postgres", "mysql", "mariadb", "mongo", "redis"]
+    name: str
+    description: str | None = None
+    image: str | None = None
+    database_name: str | None = Field(default=None, description="Defaults to the service name.")
+    database_user: str | None = Field(default=None, description="Defaults to the service name.")
+    password: str | None = Field(
+        default=None,
+        description="Database password (secret). Prefer password_cmd; never commit real passwords.",
+    )
+    password_cmd: str | None = Field(
+        default=None,
+        description="Command that outputs the database password. Resolved at apply time.",
+    )
+    env: str | None = Field(default=None, description="Environment variables as KEY=VALUE lines.")
+
+
+Service = Annotated[
+    ComposeService | ApplicationService | DatabaseService,
+    Field(discriminator="type"),
+]
 
 
 class ProjectDef(BaseModel):

--- a/dokli/state.py
+++ b/dokli/state.py
@@ -18,7 +18,15 @@ class LiveService(BaseModel):
 
     service_id: str
     app_name: str
-    type: Literal["compose", "application"]
+    type: Literal[
+        "compose",
+        "application",
+        "postgres",
+        "mysql",
+        "mariadb",
+        "mongo",
+        "redis",
+    ]
     name: str
     description: str | None = None
     source_type: str | None = None
@@ -33,6 +41,9 @@ class LiveService(BaseModel):
     compose_path: str | None = None
     compose_file: str | None = None
     command: str | None = None
+    database_name: str | None = None
+    database_user: str | None = None
+    database_password: str | None = None
     env: str | None = None
     server_id: str | None = None
 
@@ -117,6 +128,11 @@ def _collect_project(client: APIClient, raw_project: dict[str, Any], provider_ma
             services=[
                 *_collect_services("compose", environment.get("compose", []), provider_map),
                 *_collect_services("application", environment.get("applications", []), provider_map),
+                *_collect_services("postgres", environment.get("postgres", []), provider_map),
+                *_collect_services("mysql", environment.get("mysql", []), provider_map),
+                *_collect_services("mariadb", environment.get("mariadb", []), provider_map),
+                *_collect_services("mongo", environment.get("mongo", []), provider_map),
+                *_collect_services("redis", environment.get("redis", []), provider_map),
             ],
         )
         for environment in detail.get("environments", [])
@@ -130,20 +146,20 @@ def _collect_project(client: APIClient, raw_project: dict[str, Any], provider_ma
 
 
 def _collect_services(
-    service_type: Literal["compose", "application"],
+    service_type: str,
     raw_services: list[dict[str, Any]],
     provider_map: dict[str, str],
 ) -> list[LiveService]:
     services = []
     for raw in raw_services:
-        service_id = raw.get("composeId") or raw.get("applicationId")
+        service_id = _service_id(raw)
         if not service_id:
             continue
         services.append(
             LiveService(
                 service_id=service_id,
                 app_name=raw.get("appName") or "",
-                type=service_type,
+                type=service_type,  # type: ignore[arg-type]
                 name=raw.get("name") or "",
                 description=raw.get("description"),
                 source_type=raw.get("sourceType"),
@@ -158,6 +174,9 @@ def _collect_services(
                 compose_path=raw.get("composePath"),
                 compose_file=raw.get("composeFile"),
                 command=raw.get("command"),
+                database_name=raw.get("databaseName"),
+                database_user=raw.get("databaseUser"),
+                database_password=raw.get("databasePassword"),
                 env=raw.get("env"),
                 server_id=raw.get("serverId"),
             )
@@ -214,4 +233,19 @@ def _first(mapping: dict[str, Any], *keys: str) -> Any:
     for key in keys:
         if mapping.get(key) is not None:
             return mapping[key]
+    return None
+
+
+def _service_id(raw: dict[str, Any]) -> str | None:
+    for key in (
+        "composeId",
+        "applicationId",
+        "postgresId",
+        "mysqlId",
+        "mariadbId",
+        "mongoId",
+        "redisId",
+    ):
+        if raw.get(key):
+            return raw[key]
     return None

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -70,6 +70,9 @@ def _applier(mocker, state: State, responses: dict | None = None):
             return FakeResponse({"composeId": "c-new"})
         if path == "application.create":
             return FakeResponse({"applicationId": "a-new"})
+        for service_type in ("postgres", "mysql", "mariadb", "mongo", "redis"):
+            if path == f"{service_type}.create":
+                return FakeResponse({f"{service_type}Id": f"{service_type}-new"})
         return FakeResponse({})
 
     client.request.side_effect = fake_request
@@ -268,3 +271,110 @@ class TestApplyDeploy:
         deploy_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.deploy"]
         assert len(deploy_calls) == 1
         assert deploy_calls[0].args[2]["body"] == {"composeId": "c-new"}
+
+
+class TestApplyDatabases:
+    """Database apply flows."""
+
+    def test_creates_database_with_password_cmd(self, mocker):
+        """We expect a postgres create with a resolved password."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {
+                                "type": "postgres",
+                                "name": "db",
+                                "password_cmd": "echo secret123",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        client = _applier(mocker, State(connection="test-env"))
+
+        Applier(manifest, _connection()).run()
+
+        create_calls = [call for call in client.request.call_args_list if call.args[1] == "postgres.create"]
+        assert len(create_calls) == 1
+        body = create_calls[0].args[2]["body"]
+        assert body["databasePassword"] == "secret123"
+        assert body["databaseName"] == "db"
+        assert body["databaseUser"] == "db"
+        assert body["environmentId"] == "e-new"
+
+    def test_generates_password_when_missing(self, mocker):
+        """We expect a generated password with a warning when none is provided."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [{"name": "app", "services": [{"type": "redis", "name": "cache"}]}],
+            }
+        )
+        _applier(mocker, State(connection="test-env"))
+
+        report = Applier(manifest, _connection()).run()
+
+        assert any("generated a random password" in warning for warning in report.warnings)
+        assert report.actions
+
+    def test_updates_database(self, mocker):
+        """We expect a database update when fields differ."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {
+                                "type": "postgres",
+                                "name": "db",
+                                "database_name": "newdb",
+                                "password_cmd": "echo secret123",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        live = LiveService(
+            service_id="pg1",
+            app_name="db",
+            type="postgres",
+            name="db",
+            database_name="olddb",
+            database_user="db",
+            database_password="secret123",
+        )
+        state = State(
+            connection="test-env",
+            projects=[
+                LiveProject(
+                    project_id="app",
+                    name="app",
+                    environments=[
+                        LiveEnvironment(
+                            environment_id="e1",
+                            name="production",
+                            is_default=True,
+                            services=[live],
+                        )
+                    ],
+                )
+            ],
+        )
+        client = _applier(mocker, state)
+
+        Applier(manifest, _connection()).run()
+
+        update_calls = [call for call in client.request.call_args_list if call.args[1] == "postgres.update"]
+        assert len(update_calls) == 1
+        body = update_calls[0].args[2]["body"]
+        assert body["postgresId"] == "pg1"
+        assert body["databaseName"] == "newdb"
+        assert "databasePassword" not in body  # password unchanged

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -163,3 +163,32 @@ class TestBuildPlan:
 
         assert plan.items[0].action == "validate"
         assert "type mismatch" in plan.items[0].reason
+
+    def test_database_service_changes(self):
+        """We expect a database service diff to detect field changes."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "services": [
+                            {
+                                "type": "postgres",
+                                "name": "db",
+                                "database_name": "newdb",
+                                "database_user": "app",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        live = _compose_live("db", "pg1", type="postgres", database_name="olddb", database_user="app")
+        state = _state(projects=[_project_live("app", [live])])
+
+        plan = build_plan(manifest, state)
+
+        assert plan.items[0].action == "update"
+        assert "database_name" in plan.items[0].changed
+        assert "database_user" not in plan.items[0].changed

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,7 +2,7 @@
 
 from dokli.export import export_manifest
 from dokli.config import ConnectionConfig
-from dokli.manifest import ApplicationService, ComposeService
+from dokli.manifest import ApplicationService, ComposeService, DatabaseService
 from dokli.state import LiveEnvironment, LiveGitProvider, LiveProject, LiveService, State
 
 
@@ -269,3 +269,40 @@ class TestExportGitProviders:
 
         assert manifest.git_providers == []
         assert any("unsupported type" in warning for warning in warnings)
+
+
+class TestExportDatabases:
+    """Database export tests."""
+
+    def test_database_export_redacts_password(self, mocker):
+        """We expect a database to be exported without its password."""
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    _project_live(
+                        "app",
+                        [
+                            _live_service(
+                                "postgres",
+                                "db",
+                                database_name="appdb",
+                                database_user="app",
+                                database_password="hunter2",
+                                docker_image="postgres:16",
+                            )
+                        ],
+                    )
+                ],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection())
+
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, DatabaseService)
+        assert service.database_name == "appdb"
+        assert service.password is None
+        assert service.password_cmd is None
+        assert any("password" in warning and "not exported" in warning for warning in warnings)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,7 +3,7 @@
 import pytest
 import yaml
 
-from dokli.manifest import ApplicationService, ComposeService, Manifest
+from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest
 
 
 def _load_manifest(raw_yaml: str) -> Manifest:
@@ -49,6 +49,26 @@ class TestManifest:
         service = manifest.projects[0].services
         assert isinstance(service[0], ComposeService)
         assert isinstance(service[1], ApplicationService)
+
+    def test_database_service(self):
+        """We expect database services to be parsed."""
+        manifest = _load_manifest(
+            """
+            connection: prod
+            projects:
+              - name: myapp
+                services:
+                  - type: postgres
+                    name: db
+                    database_name: appdb
+                    database_user: app
+                    password_cmd: "secret-tool lookup dokli db"
+            """
+        )
+        service = manifest.projects[0].services[0]
+        assert isinstance(service, DatabaseService)
+        assert service.database_name == "appdb"
+        assert service.password_cmd == "secret-tool lookup dokli db"
 
     def test_get_git_provider_raises_for_unknown(self):
         """We expect an error when a git provider is not defined."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -136,3 +136,32 @@ class TestCollectState:
         assert "project.one" in paths
         assert "gitProvider.getAll" in paths
         assert "server.all" in paths
+
+    def test_collects_database_services(self, mocker):
+        """We expect database services to be collected."""
+        responses = _responses()
+        responses["project.one"]["environments"][0]["postgres"] = [
+            {
+                "postgresId": "pg1",
+                "appName": "db",
+                "name": "db",
+                "databaseName": "appdb",
+                "databaseUser": "app",
+                "databasePassword": "hunter2",
+                "dockerImage": "postgres:16",
+                "serverId": "srv1",
+                "description": None,
+            }
+        ]
+        client = mocker.Mock()
+        client.request.side_effect = lambda _method, path, _params: FakeResponse(responses[path])
+        mocker.patch("dokli.state.APIClient", return_value=client)
+
+        state = collect_state(_connection())
+
+        service = state.projects[0].environments[0].services[-1]
+        assert service.type == "postgres"
+        assert service.service_id == "pg1"
+        assert service.database_name == "appdb"
+        assert service.database_user == "app"
+        assert service.database_password == "hunter2"


### PR DESCRIPTION
Part of #37 — Phase f1 of as-code v2: database services.

## What's in this PR

- **Manifest** — new `DatabaseService` type (`postgres`, `mysql`, `mariadb`, `mongo`, `redis`) with `database_name`, `database_user`, `image`, `env`, and password handling:
  - `password` (explicit, discouraged) or `password_cmd` (external reference, recommended)
  - if neither is set, apply **generates a random password** and reports it as a warning
- **State** — collects database services from environments; `LiveService` gains `database_name/user/password`.
- **Plan** — database services are diffed (description, image, database_name, database_user, password when explicitly set, env).
- **Apply** — `*create` with the per-type required fields (`databasePassword` is mandatory at create), then `*update` for deltas. Passwords are **not** reset on update unless the manifest provides one.
- **Export** — databases reverse-engineered; the password is **never** exported (warning added).

## Verified

- `dokli plan` + `dokli apply --dry-run` against `dokploy.meche.lan` show redis/postgres creates correctly (dry-run only; no DB was created).
- `make lint` ✓, `make test` → 60 passed ✓

Next: f2 (multi-environment) on `DOKLI-37-f2`.
