### PR TITLE
Dokli as Code v2 (f2): multi-environment

### DIFF
--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -15,7 +15,7 @@ from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.diff import resolve_compose_file
 from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Service
-from dokli.state import LiveGitProvider, LiveProject, LiveService, collect_state
+from dokli.state import LiveGitProvider, LiveProject, LiveService, State, collect_state
 
 
 class ApplyAction(BaseModel):
@@ -24,6 +24,7 @@ class ApplyAction(BaseModel):
     action: Literal["create", "update", "validate", "skip"]
     kind: Literal[
         "project",
+        "environment",
         "compose",
         "application",
         "postgres",
@@ -56,10 +57,12 @@ class Applier:
         self.deploy = deploy
         self.report = ApplyReport()
         self._live_providers: dict[str, LiveGitProvider] = {}
+        self._state: State = State(connection="")
 
     def run(self, dry_run: bool = False) -> ApplyReport:
         """Apply the manifest, optionally only planning (dry_run)."""
         state = collect_state(self.connection, client=self.client)
+        self._state = state
         self._live_providers = {provider.name: provider for provider in state.git_providers}
         self._validate_git_providers()
 
@@ -111,24 +114,30 @@ class Applier:
             self.report.actions.append(
                 ApplyAction(action="create", kind="project", project=project_def.name, name=project_def.name)
             )
-            for service_def in project_def.services:
+            self._plan_services(project_def, project_def.services)
+            for env_def in project_def.environments:
                 self.report.actions.append(
                     ApplyAction(
-                        action="create", kind=service_def.type, project=project_def.name, name=service_def.name
+                        action="create", kind="environment", project=project_def.name, name=env_def.name
                     )
                 )
+                self._plan_services(project_def, env_def.services)
             return
 
         payload: dict[str, Any] = {"name": project_def.name}
         if project_def.description:
             payload["description"] = project_def.description
         response = self.client.request("POST", "project.create", {"body": payload}).json()
-        environment_id = response["environment"]["environmentId"]
+        default_environment_id = response["environment"]["environmentId"]
+        project_id = response["project"]["projectId"]
         self.report.actions.append(
             ApplyAction(action="create", kind="project", project=project_def.name, name=project_def.name)
         )
-        for service_def in project_def.services:
-            self._create_service(project_def.name, service_def, environment_id, dry_run=False)
+        self._apply_services(project_def, project_def.services, default_environment_id)
+        for env_def in project_def.environments:
+            environment_id = self._create_environment(project_def.name, project_id, env_def.name, dry_run=False)
+            if environment_id:
+                self._apply_services(project_def, env_def.services, environment_id)
 
     def _apply_to_project(self, project_def, live_project: LiveProject, dry_run: bool) -> None:
         default_environment = next(
@@ -146,13 +155,66 @@ class Applier:
                 )
             )
             return
-        live_services = {service.name: service for service in default_environment.services}
-        for service_def in project_def.services:
+        self._apply_services(project_def, project_def.services, default_environment.environment_id, dry_run)
+
+        for env_def in project_def.environments:
+            live_env = next(
+                (environment for environment in live_project.environments if environment.name == env_def.name),
+                None,
+            )
+            if live_env is None:
+                environment_id = self._create_environment(
+                    project_def.name, live_project.project_id, env_def.name, dry_run
+                )
+            else:
+                environment_id = live_env.environment_id
+            if environment_id:
+                self._apply_services(project_def, env_def.services, environment_id, dry_run)
+
+    def _apply_services(self, project_def, service_defs, environment_id: str, dry_run: bool = False) -> None:
+        """Create or update a list of services within an environment."""
+        live_services = self._live_services(project_def.name, environment_id)
+        for service_def in service_defs:
             live_service = live_services.get(service_def.name)
             if live_service is None:
-                self._create_service(project_def.name, service_def, default_environment.environment_id, dry_run)
+                self._create_service(project_def.name, service_def, environment_id, dry_run)
             else:
                 self._update_service(project_def.name, service_def, live_service, dry_run)
+
+    def _live_services(self, project_name: str, environment_id: str) -> dict[str, LiveService]:
+        """Resolve live services for an environment id.
+
+        Uses the state snapshot captured at the start of the run.
+        """
+        state = self._state
+        for project in state.projects:
+            if project.name != project_name:
+                continue
+            for environment in project.environments:
+                if environment.environment_id == environment_id:
+                    return {service.name: service for service in environment.services}
+        return {}
+
+    def _plan_services(self, project_def, service_defs) -> None:
+        """Record create actions for services (dry-run helper)."""
+        for service_def in service_defs:
+            self.report.actions.append(
+                ApplyAction(action="create", kind=service_def.type, project=project_def.name, name=service_def.name)
+            )
+
+    def _create_environment(self, project_name: str, project_id: str, env_name: str, dry_run: bool) -> str | None:
+        """Ensure a named environment exists and return its id."""
+        if dry_run:
+            self.report.actions.append(
+                ApplyAction(action="create", kind="environment", project=project_name, name=env_name)
+            )
+            return None
+        payload = {"projectId": project_id, "name": env_name}
+        response = self.client.request("POST", "environment.create", {"body": payload}).json()
+        self.report.actions.append(
+            ApplyAction(action="create", kind="environment", project=project_name, name=env_name)
+        )
+        return response["environmentId"]
 
     def _create_service(self, project_name: str, service_def: Service, environment_id: str, dry_run: bool) -> None:
         if dry_run:

--- a/dokli/diff.py
+++ b/dokli/diff.py
@@ -15,6 +15,7 @@ class PlanItem(BaseModel):
     action: Literal["create", "update", "validate"]
     kind: Literal[
         "project",
+        "environment",
         "compose",
         "application",
         "postgres",
@@ -69,41 +70,96 @@ def build_plan(manifest: Manifest, state: State) -> Plan:
                         reason="Service will be created with the project.",
                     )
                 )
-            continue
-
-        default_environment = _default_environment(live_project)
-        live_services = {
-            service.name: service for service in (default_environment.services if default_environment else [])
-        }
-
-        for service_def in project_def.services:
-            live_service = live_services.get(service_def.name)
-            if live_service is None:
+            for env_def in project_def.environments:
                 items.append(
                     PlanItem(
                         action="create",
-                        kind=service_def.type,
+                        kind="environment",
                         project=project_def.name,
-                        name=service_def.name,
-                        reason="Service does not exist.",
+                        name=env_def.name,
+                        reason="Environment will be created with the project.",
                     )
                 )
-            else:
-                changed = _service_changes(service_def, live_service)
-                if changed:
+                for service_def in env_def.services:
                     items.append(
                         PlanItem(
-                            action="update",
+                            action="create",
                             kind=service_def.type,
                             project=project_def.name,
                             name=service_def.name,
-                            changed=changed,
+                            reason="Service will be created with the environment.",
                         )
                     )
+            continue
+
+        default_environment = _default_environment(live_project)
+        _plan_services(
+            project_def,
+            project_def.services,
+            default_environment.services if default_environment else [],
+            items,
+        )
+
+        for env_def in project_def.environments:
+            live_env = next(
+                (environment for environment in live_project.environments if environment.name == env_def.name),
+                None,
+            )
+            if live_env is None:
+                items.append(
+                    PlanItem(
+                        action="create",
+                        kind="environment",
+                        project=project_def.name,
+                        name=env_def.name,
+                        reason="Environment does not exist.",
+                    )
+                )
+                for service_def in env_def.services:
+                    items.append(
+                        PlanItem(
+                            action="create",
+                            kind=service_def.type,
+                            project=project_def.name,
+                            name=service_def.name,
+                            reason="Service will be created with the environment.",
+                        )
+                    )
+            else:
+                _plan_services(project_def, env_def.services, live_env.services, items)
 
     _plan_git_providers(manifest, state, items)
 
     return Plan(connection=state.connection, items=items)
+
+
+def _plan_services(project_def, service_defs, live_services, items: list[PlanItem]) -> None:
+    """Plan services of one environment against its live services."""
+    live = {service.name: service for service in live_services}
+    for service_def in service_defs:
+        live_service = live.get(service_def.name)
+        if live_service is None:
+            items.append(
+                PlanItem(
+                    action="create",
+                    kind=service_def.type,
+                    project=project_def.name,
+                    name=service_def.name,
+                    reason="Service does not exist.",
+                )
+            )
+        else:
+            changed = _service_changes(service_def, live_service)
+            if changed:
+                items.append(
+                    PlanItem(
+                        action="update",
+                        kind=service_def.type,
+                        project=project_def.name,
+                        name=service_def.name,
+                        changed=changed,
+                    )
+                )
 
 
 def _plan_git_providers(manifest: Manifest, state: State, items: list[PlanItem]) -> None:

--- a/dokli/export.py
+++ b/dokli/export.py
@@ -10,6 +10,7 @@ from dokli.manifest import (
     ApplicationService,
     ComposeService,
     DatabaseService,
+    EnvironmentDef,
     GitProvider,
     GitSource,
     Manifest,
@@ -71,14 +72,31 @@ def _export_project(project, include_secrets: bool, warnings: list[str]) -> Proj
         (environment for environment in project.environments if environment.is_default),
         None,
     )
-    services: list[Service] = []
+    default_services: list[Service] = []
     if default_environment is not None:
-        services = [
+        default_services = [
             service
             for live in default_environment.services
             if (service := _export_service(live, include_secrets, warnings)) is not None
         ]
-    return ProjectDef(name=project.name, description=project.description or None, services=services)
+    environments = [
+        EnvironmentDef(
+            name=environment.name,
+            services=[
+                service
+                for live in environment.services
+                if (service := _export_service(live, include_secrets, warnings)) is not None
+            ],
+        )
+        for environment in project.environments
+        if not environment.is_default and environment.services
+    ]
+    return ProjectDef(
+        name=project.name,
+        description=project.description or None,
+        services=default_services,
+        environments=environments,
+    )
 
 
 def _export_service(live: LiveService, include_secrets: bool, warnings: list[str]) -> Service | None:

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -105,12 +105,26 @@ Service = Annotated[
 ]
 
 
+class EnvironmentDef(BaseModel):
+    """A named environment with its services."""
+
+    name: str
+    services: list[Service] = Field(default_factory=list)
+
+
 class ProjectDef(BaseModel):
     """A project with its services."""
 
     name: str
     description: str | None = None
-    services: list[Service] = Field(default_factory=list)
+    services: list[Service] = Field(
+        default_factory=list,
+        description="Services in the project's default environment.",
+    )
+    environments: list[EnvironmentDef] = Field(
+        default_factory=list,
+        description="Named environments (besides the default one).",
+    )
 
 
 class Manifest(BaseModel):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -70,6 +70,8 @@ def _applier(mocker, state: State, responses: dict | None = None):
             return FakeResponse({"composeId": "c-new"})
         if path == "application.create":
             return FakeResponse({"applicationId": "a-new"})
+        if path == "environment.create":
+            return FakeResponse({"environmentId": "env-staging"})
         for service_type in ("postgres", "mysql", "mariadb", "mongo", "redis"):
             if path == f"{service_type}.create":
                 return FakeResponse({f"{service_type}Id": f"{service_type}-new"})
@@ -271,6 +273,92 @@ class TestApplyDeploy:
         deploy_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.deploy"]
         assert len(deploy_calls) == 1
         assert deploy_calls[0].args[2]["body"] == {"composeId": "c-new"}
+
+
+class TestApplyEnvironments:
+    """Multi-environment apply flows."""
+
+    def test_creates_missing_environment(self, mocker):
+        """We expect a named environment to be created when missing."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "environments": [
+                            {
+                                "name": "staging",
+                                "services": [{"type": "compose", "name": "api", "compose_file": "x: 1"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        state = State(connection="test-env", projects=[_project_live("app", [])])
+        client = _applier(mocker, state)
+
+        Applier(manifest, _connection()).run()
+
+        env_calls = [call for call in client.request.call_args_list if call.args[1] == "environment.create"]
+        assert len(env_calls) == 1
+        assert env_calls[0].args[2]["body"] == {"projectId": "app", "name": "staging"}
+        compose_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.create"]
+        assert compose_calls
+        assert compose_calls[0].args[2]["body"]["environmentId"] == "env-staging"
+
+    def test_uses_existing_environment(self, mocker):
+        """We expect existing named environments to be reused."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "environments": [
+                            {
+                                "name": "staging",
+                                "services": [{"type": "compose", "name": "api", "compose_file": "x: 1"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        staging = LiveEnvironment(
+            environment_id="e-staging",
+            name="staging",
+            is_default=False,
+            services=[],
+        )
+        state = State(
+            connection="test-env",
+            projects=[
+                LiveProject(
+                    project_id="app",
+                    name="app",
+                    environments=[
+                        LiveEnvironment(
+                            environment_id="e1",
+                            name="production",
+                            is_default=True,
+                            services=[],
+                        ),
+                        staging,
+                    ],
+                )
+            ],
+        )
+        client = _applier(mocker, state)
+
+        Applier(manifest, _connection()).run()
+
+        env_calls = [call for call in client.request.call_args_list if call.args[1] == "environment.create"]
+        assert env_calls == []
+        compose_calls = [call for call in client.request.call_args_list if call.args[1] == "compose.create"]
+        assert compose_calls
+        assert compose_calls[0].args[2]["body"]["environmentId"] == "e-staging"
 
 
 class TestApplyDatabases:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -192,3 +192,71 @@ class TestBuildPlan:
         assert plan.items[0].action == "update"
         assert "database_name" in plan.items[0].changed
         assert "database_user" not in plan.items[0].changed
+
+    def test_missing_environment_to_create(self):
+        """We expect a plan with creates for a missing named environment."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "environments": [
+                            {
+                                "name": "staging",
+                                "services": [{"type": "compose", "name": "api", "compose_file": "x: 1"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        state = _state(projects=[_project_live("app", [])])
+
+        plan = build_plan(manifest, state)
+
+        assert plan.items[0].action == "create"
+        assert plan.items[0].kind == "environment"
+        assert plan.items[0].name == "staging"
+        assert plan.items[1].kind == "compose"
+        assert plan.items[1].name == "api"
+
+    def test_existing_environment_service_change(self):
+        """We expect an update for a service inside an existing environment."""
+        manifest = Manifest.model_validate(
+            {
+                "connection": "test-env",
+                "projects": [
+                    {
+                        "name": "app",
+                        "environments": [
+                            {
+                                "name": "staging",
+                                "services": [{"type": "compose", "name": "api", "compose_file": "version: '3.8'"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        staging = LiveEnvironment(
+            environment_id="e-staging",
+            name="staging",
+            is_default=False,
+            services=[_compose_live("api", "s2")],
+        )
+        state = _state(
+            projects=[
+                LiveProject(
+                    project_id="app",
+                    name="app",
+                    environments=[staging],
+                )
+            ]
+        )
+
+        plan = build_plan(manifest, state)
+
+        assert plan.items[0].action == "update"
+        assert plan.items[0].name == "api"
+        assert plan.items[0].changed == ["compose_file"]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -306,3 +306,47 @@ class TestExportDatabases:
         assert service.password is None
         assert service.password_cmd is None
         assert any("password" in warning and "not exported" in warning for warning in warnings)
+
+
+class TestExportEnvironments:
+    """Multi-environment export tests."""
+
+    def test_exports_named_environments(self, mocker):
+        """We expect non-default environments to be exported under environments."""
+        default_env = LiveEnvironment(
+            environment_id="e1",
+            name="production",
+            is_default=True,
+            services=[
+                _live_service("compose", "backend", source_type="raw", compose_file="version: '3'"),
+            ],
+        )
+        staging_env = LiveEnvironment(
+            environment_id="e2",
+            name="staging",
+            is_default=False,
+            services=[
+                _live_service("compose", "api", source_type="raw", compose_file="version: '3'"),
+            ],
+        )
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[
+                    LiveProject(
+                        project_id="app",
+                        name="app",
+                        environments=[default_env, staging_env],
+                    )
+                ],
+            ),
+        )
+
+        manifest, _ = export_manifest(_connection())
+
+        project = manifest.projects[0]
+        assert [s.name for s in project.services] == ["backend"]
+        assert len(project.environments) == 1
+        assert project.environments[0].name == "staging"
+        assert [s.name for s in project.environments[0].services] == ["api"]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -70,6 +70,28 @@ class TestManifest:
         assert service.database_name == "appdb"
         assert service.password_cmd == "secret-tool lookup dokli db"
 
+    def test_environments(self):
+        """We expect named environments to be parsed."""
+        manifest = _load_manifest(
+            """
+            connection: prod
+            projects:
+              - name: myapp
+                services:
+                  - type: compose
+                    name: backend
+                environments:
+                  - name: staging
+                    services:
+                      - type: compose
+                        name: api
+            """
+        )
+        project = manifest.projects[0]
+        assert project.services[0].name == "backend"
+        assert project.environments[0].name == "staging"
+        assert project.environments[0].services[0].name == "api"
+
     def test_get_git_provider_raises_for_unknown(self):
         """We expect an error when a git provider is not defined."""
         manifest = _load_manifest(


### PR DESCRIPTION
Part of #37 — Phase f2 of as-code v2: multiple environments per project.

## What's in this PR

- **Manifest** — `ProjectDef.environments: [{name, services}]` alongside the flat `services` (default env). Fully backward compatible.
- **Plan** — named environments are diffed: missing env → `create` (with its services); existing env → per-service create/update.
- **Apply** — named environments are ensured (`environment.create {projectId, name}`) and their services applied; existing envs are reused. Live services are resolved from the state snapshot by environment.
- **Export** — non-default environments are exported under `environments`; default-env services stay flat under `services`.

## Verified

- `dokli plan` + `dokli apply --dry-run` against `dokploy.meche.lan`:
  ```
  create  project     dokli-env-test  dokli-env-test
  create  compose     dokli-env-test  app-default
  create  environment dokli-env-test  staging
  create  compose     dokli-env-test  app-staging
  ```
  (dry-run only; nothing created on the instance)
- `make lint` ✓, `make test` → 68 passed ✓

This completes #37 (databases + multi-environment).
