### PR TITLE
Generative TUI (R0): schema-driven engine + generic screens

### DIFF
--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -19,7 +19,7 @@ from dokli.openapi_cli import register_connections
 from dokli.state import collect_state
 
 try:
-    from dokli.tui import app as tui
+    from dokli.tui.app import app as tui
 
     _tui_loaded = True
 except ImportError:

--- a/dokli/tui/__init__.py
+++ b/dokli/tui/__init__.py
@@ -1,8 +1,5 @@
 """Dokli TUI."""
 
-from .app import DokliApp, app
+from .app import DokliApp
 
-__all__ = (
-    "DokliApp",
-    "app",
-)
+__all__ = ("DokliApp",)

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -6,9 +6,11 @@ from textual import events, log
 from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header, Static
 
+from dokli.api_client import APIClient
 from dokli.config import Config, ConnectionConfig
+from dokli.tui.engine import parse_spec
 from dokli.tui.screens.connections import ConnectionsScreen
-from dokli.tui.screens.projects import ProjectsScreen
+from dokli.tui.screens.generic.home import HomeScreen
 from dokli.tui.screens.settings import SettingsScreen
 
 TUI_PATH = Path(__file__).parent
@@ -54,11 +56,16 @@ class DokliApp(App):
             self.bell()
 
     def on_connections_screen_set_connection(self, event: ConnectionsScreen.SetConnection) -> None:
-        """Set the active connection."""
+        """Set the active connection and open the entity browser."""
         self.connection = event.connection
         log.info(f"Setting connection: {event.connection}")
-        self.install_screen(ProjectsScreen(name="Projects", connection=self.connection), name="Projects")
-        self.push_screen("Projects")
+        schema = APIClient(event.connection).schema
+        registry = parse_spec(schema)
+        self.install_screen(
+            HomeScreen(name="Home", connection=self.connection, registry=registry),
+            name="Home",
+        )
+        self.push_screen("Home")
 
     def action_connections(self) -> None:
         """Action connections."""

--- a/dokli/tui/engine/__init__.py
+++ b/dokli/tui/engine/__init__.py
@@ -6,7 +6,14 @@ generic list/detail/form views for any Dokploy API version.
 
 from dokli.tui.engine.introspect import field_label, infer_columns, record_id, record_subtitle, record_title
 from dokli.tui.engine.schemas import build_form_model
-from dokli.tui.engine.spec import Entity, EntityAction, EntityRegistry, classify, parse_spec
+from dokli.tui.engine.spec import (
+    Entity,
+    EntityAction,
+    EntityRegistry,
+    classify,
+    nested_child_entity,
+    parse_spec,
+)
 
 __all__ = [
     "Entity",
@@ -16,6 +23,7 @@ __all__ = [
     "classify",
     "field_label",
     "infer_columns",
+    "nested_child_entity",
     "parse_spec",
     "record_id",
     "record_subtitle",

--- a/dokli/tui/engine/__init__.py
+++ b/dokli/tui/engine/__init__.py
@@ -7,6 +7,7 @@ generic list/detail/form views for any Dokploy API version.
 from dokli.tui.engine.introspect import field_label, infer_columns, record_id, record_subtitle, record_title
 from dokli.tui.engine.schemas import build_form_model
 from dokli.tui.engine.spec import (
+    DESTRUCTIVE_VERBS,
     Entity,
     EntityAction,
     EntityRegistry,
@@ -16,6 +17,7 @@ from dokli.tui.engine.spec import (
 )
 
 __all__ = [
+    "DESTRUCTIVE_VERBS",
     "Entity",
     "EntityAction",
     "EntityRegistry",

--- a/dokli/tui/engine/__init__.py
+++ b/dokli/tui/engine/__init__.py
@@ -1,0 +1,23 @@
+"""Schema-driven TUI engine.
+
+Parses the OpenAPI document into an entity registry so the TUI can render
+generic list/detail/form views for any Dokploy API version.
+"""
+
+from dokli.tui.engine.introspect import field_label, infer_columns, record_id, record_subtitle, record_title
+from dokli.tui.engine.schemas import build_form_model
+from dokli.tui.engine.spec import Entity, EntityAction, EntityRegistry, classify, parse_spec
+
+__all__ = [
+    "Entity",
+    "EntityAction",
+    "EntityRegistry",
+    "build_form_model",
+    "classify",
+    "field_label",
+    "infer_columns",
+    "parse_spec",
+    "record_id",
+    "record_subtitle",
+    "record_title",
+]

--- a/dokli/tui/engine/introspect.py
+++ b/dokli/tui/engine/introspect.py
@@ -1,0 +1,63 @@
+"""Helpers to render live API data in generic views.
+
+Dokploy's OpenAPI document does not describe response bodies, so list and
+detail views infer their columns/fields from the actual data returned by the
+API.
+"""
+
+import re
+from typing import Any
+
+NOISE_FIELDS = {"createdAt", "updatedAt", "refreshToken", "organizationId", "adminId", "env"}
+
+
+def field_label(name: str) -> str:
+    """Turn a camelCase/snake_case field name into a title."""
+    label = re.sub(r"(?<!^)(?=[A-Z])", " ", name).replace("_", " ")
+    return label[:1].upper() + label[1:]
+
+
+def record_id(record: dict[str, Any], entity_name: str = "") -> str | None:
+    """Best-effort id for a record."""
+    if entity_name:
+        candidate = record.get(f"{entity_name}Id")
+        if candidate:
+            return str(candidate)
+    candidate = record.get("id")
+    if candidate:
+        return str(candidate)
+    for key, value in record.items():
+        if key.endswith("Id") and value:
+            return str(value)
+    return None
+
+
+def record_title(record: dict[str, Any]) -> str:
+    """A short title for a record (used in lists)."""
+    for key in ("name", "appName", "title", "label"):
+        value = record.get(key)
+        if value:
+            return str(value)
+    return str(record_id(record) or "record")
+
+
+def record_subtitle(record: dict[str, Any], entity_name: str = "") -> str:
+    """A summary line for a record (used in lists)."""
+    parts = []
+    for key in ("description", "applicationStatus", "composeStatus"):
+        value = record.get(key)
+        if value:
+            parts.append(f"{field_label(key)}: {value}")
+    return " · ".join(parts)
+
+
+def infer_columns(records: list[dict[str, Any]], entity_name: str = "") -> list[str]:
+    """Pick columns for a list view from the first record."""
+    if not records:
+        return [entity_name or "record"]
+    keys = list(records[0].keys())
+    preferred = [f"{entity_name}Id", "id", "name", "appName", "description", "applicationStatus", "composeStatus"]
+    columns = [key for key in preferred if key in keys]
+    if not columns:
+        columns = [key for key in keys if key not in NOISE_FIELDS][:4]
+    return columns[:5]

--- a/dokli/tui/engine/schemas.py
+++ b/dokli/tui/engine/schemas.py
@@ -16,6 +16,17 @@ JSON_TO_ANNOTATION = {
 
 SECRET_KEY = re.compile(r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|access[_-]?key)")
 
+# Server-managed fields that should not be edited in forms.
+READ_ONLY_FIELDS = {
+    "createdAt",
+    "updatedAt",
+    "organizationId",
+    "adminId",
+    "applicationStatus",
+    "composeStatus",
+    "refreshToken",
+}
+
 
 def build_form_model(schema: dict, name: str = "ActionForm") -> type[BaseModel]:
     """Build a pydantic model from an OpenAPI request body schema.
@@ -27,6 +38,8 @@ def build_form_model(schema: dict, name: str = "ActionForm") -> type[BaseModel]:
     """
     fields: dict[str, Any] = {}
     for field_name, prop in schema.get("properties", {}).items():
+        if field_name in READ_ONLY_FIELDS:
+            continue
         annotation = _annotation_for(field_name, prop)
         label = _label_for(field_name)
         description = prop.get("description")

--- a/dokli/tui/engine/schemas.py
+++ b/dokli/tui/engine/schemas.py
@@ -1,0 +1,50 @@
+"""JSON Schema → pydantic model (for generic action forms)."""
+
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, SecretStr, create_model
+
+JSON_TO_ANNOTATION = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+SECRET_KEY = re.compile(r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|access[_-]?key)")
+
+
+def build_form_model(schema: dict, name: str = "ActionForm") -> type[BaseModel]:
+    """Build a pydantic model from an OpenAPI request body schema.
+
+    Used to reuse the existing generic :class:`~dokli.tui.forms.Form` widget,
+    which derives controls and validation from a pydantic model. All fields are
+    optional (default ``None``); requiredness is enforced by the form screen
+    from the schema's ``required`` list.
+    """
+    fields: dict[str, Any] = {}
+    for field_name, prop in schema.get("properties", {}).items():
+        annotation = _annotation_for(field_name, prop)
+        label = _label_for(field_name)
+        description = prop.get("description")
+        if "enum" in prop:
+            options = ", ".join(str(value) for value in prop["enum"])
+            description = f"{description} [{options}]" if description else f"Options: {options}"
+        fields[field_name] = (annotation | None, Field(None, title=label, description=description))
+    return create_model(name, **fields)
+
+
+def _annotation_for(field_name: str, prop: dict[str, Any]) -> Any:
+    if SECRET_KEY.search(field_name):
+        return SecretStr
+    if "enum" in prop and prop.get("type") == "string":
+        return Literal[tuple(prop["enum"])]
+    return JSON_TO_ANNOTATION.get(str(prop.get("type")), str)
+
+
+def _label_for(field_name: str) -> str:
+    label = re.sub(r"(?<!^)(?=[A-Z])", " ", field_name).replace("_", " ")
+    return label[:1].upper() + label[1:]

--- a/dokli/tui/engine/spec.py
+++ b/dokli/tui/engine/spec.py
@@ -29,6 +29,32 @@ class Entity(BaseModel):
         """Get an action by verb."""
         return self.actions.get(verb)
 
+    @property
+    def listable(self) -> bool:
+        """Whether the entity has an ``all`` action (top-level listable)."""
+        return "all" in self.actions
+
+    @property
+    def parent_entity(self) -> str | None:
+        """The parent entity, inferred from foreign keys in the create schema.
+
+        A required (or present) ``<parent>Id`` field in the request body (other
+        than the entity's own id and ``serverId`` placement) points to its
+        parent. E.g. ``compose.create`` requires ``environmentId``.
+        """
+        create = self.actions.get("create")
+        if create is None:
+            return None
+        schema = create.request_schema
+        fields = list(schema.get("required", [])) + list(schema.get("properties", {}))
+        for field in fields:
+            if not field.endswith("Id"):
+                continue
+            if field in (f"{self.name}Id", "serverId"):
+                continue
+            return field[:-2]
+        return None
+
 
 class EntityRegistry(BaseModel):
     """All entities discovered from an OpenAPI document."""
@@ -43,26 +69,57 @@ class EntityRegistry(BaseModel):
         """Get an entity by name."""
         return self.entities.get(name)
 
+    def listable(self) -> list[str]:
+        """Entities that can be listed at the top level (have ``all``)."""
+        return sorted(name for name, entity in self.entities.items() if entity.listable)
+
+    def navigation_path(self, name: str) -> list[str]:
+        """Chain of ancestors from a top-level entity down to ``name``."""
+        path = [name]
+        seen = {name}
+        current = name
+        while True:
+            entity = self.get(current)
+            parent = entity.parent_entity if entity else None
+            if not parent or parent in seen or parent not in self.entities:
+                break
+            path.append(parent)
+            seen.add(parent)
+            current = parent
+        return list(reversed(path))
+
 
 LIST_VERBS = {"all"}
 DETAIL_VERBS = {"one"}
 DESTRUCTIVE_VERBS = {"remove", "delete"}
 FORM_PREFIXES = ("create", "update", "save", "edit", "new")
 
-CORE_ENTITIES = [
-    "project",
-    "compose",
-    "application",
-    "postgres",
-    "mysql",
-    "mariadb",
-    "mongo",
-    "redis",
-    "libsql",
-    "server",
-    "domain",
-    "deployment",
-]
+# Response keys (nested arrays) → child entity name.
+NESTED_CHILD_KEYS = {
+    "environments": "environment",
+    "applications": "application",
+    "compose": "compose",
+    "postgres": "postgres",
+    "mysql": "mysql",
+    "mariadb": "mariadb",
+    "mongo": "mongo",
+    "redis": "redis",
+    "libsql": "libsql",
+    "domains": "domain",
+    "ports": "port",
+    "mounts": "mount",
+    "backups": "backup",
+    "schedules": "schedule",
+    "security": "security",
+    "redirects": "redirects",
+    "patches": "patch",
+    "previewDeployments": "previewDeployment",
+}
+
+
+def nested_child_entity(key: str) -> str | None:
+    """Map a nested response array key to its child entity, if known."""
+    return NESTED_CHILD_KEYS.get(key)
 
 
 def classify(action: EntityAction) -> str:

--- a/dokli/tui/engine/spec.py
+++ b/dokli/tui/engine/spec.py
@@ -1,0 +1,111 @@
+"""OpenAPI document → entity registry."""
+
+from pydantic import BaseModel, Field
+
+
+class EntityAction(BaseModel):
+    """An API action of an entity (e.g. ``project.create``)."""
+
+    verb: str
+    method: str
+    route: str
+    summary: str = ""
+    request_schema: dict = Field(default_factory=dict)
+    param_names: list[str] = Field(default_factory=list)
+
+    @property
+    def label(self) -> str:
+        """A human-friendly label for the action."""
+        return f"{self.verb} ({self.method})"
+
+
+class Entity(BaseModel):
+    """An API entity with its actions."""
+
+    name: str
+    actions: dict[str, EntityAction] = Field(default_factory=dict)
+
+    def get(self, verb: str) -> EntityAction | None:
+        """Get an action by verb."""
+        return self.actions.get(verb)
+
+
+class EntityRegistry(BaseModel):
+    """All entities discovered from an OpenAPI document."""
+
+    entities: dict[str, Entity] = Field(default_factory=dict)
+
+    def names(self) -> list[str]:
+        """Sorted entity names."""
+        return sorted(self.entities)
+
+    def get(self, name: str) -> Entity | None:
+        """Get an entity by name."""
+        return self.entities.get(name)
+
+
+LIST_VERBS = {"all"}
+DETAIL_VERBS = {"one"}
+DESTRUCTIVE_VERBS = {"remove", "delete"}
+FORM_PREFIXES = ("create", "update", "save", "edit", "new")
+
+CORE_ENTITIES = [
+    "project",
+    "compose",
+    "application",
+    "postgres",
+    "mysql",
+    "mariadb",
+    "mongo",
+    "redis",
+    "libsql",
+    "server",
+    "domain",
+    "deployment",
+]
+
+
+def classify(action: EntityAction) -> str:
+    """Classify an action into a generic interaction type."""
+    if action.verb in LIST_VERBS:
+        return "list"
+    if action.verb in DETAIL_VERBS:
+        return "detail"
+    if action.verb in DESTRUCTIVE_VERBS:
+        return "action"
+    if action.verb.startswith(FORM_PREFIXES):
+        return "form"
+    return "action"
+
+
+def parse_spec(schema: dict) -> EntityRegistry:
+    """Build an entity registry from an OpenAPI document."""
+    registry = EntityRegistry()
+    for path, methods in schema.get("paths", {}).items():
+        route = path.strip("/")
+        if "." not in route:
+            continue
+        entity_name, _, verb = route.partition(".")
+        for method, details in methods.items():
+            action = EntityAction(
+                verb=verb,
+                method=method.upper(),
+                route=route,
+                summary=(details.get("summary") or details.get("description") or "").strip(),
+                request_schema=_extract_request_schema(details),
+                param_names=[parameter["name"] for parameter in details.get("parameters", [])],
+            )
+            entity = registry.entities.setdefault(entity_name, Entity(name=entity_name))
+            entity.actions[verb] = action
+    return registry
+
+
+def _extract_request_schema(details: dict) -> dict:
+    body = details.get("requestBody", {})
+    schema = body.get("content", {}).get("application/json", {}).get("schema", {})
+    if schema.get("type") != "object":
+        return {}
+    return {
+        "properties": schema.get("properties", {}),
+        "required": schema.get("required", []),
+    }

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel, SecretBytes, SecretStr, ValidationError
 from pydantic_core import ErrorDetails
-from textual import log
 from textual.containers import Container
 from textual.css.query import NoMatches
 from textual.message import Message
@@ -150,15 +149,25 @@ class Form(Generic[M], Container):
         self.validate_on_input = validate_on_input
 
     @classmethod
-    def from_model(cls, model: type[M], instance: M | None = None, **kwargs) -> "Form":
-        """Construct a form form a model."""
-        data = cls._get_data_from_instance(instance)
-        log("Form", data)
+    def from_model(
+        cls,
+        model: type[M],
+        instance: M | None = None,
+        data: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> "Form":
+        """Construct a form from a model.
+
+        Controls are prefilled from ``data`` when given, otherwise from the
+        ``instance``.
+        """
+        if data is None:
+            data = cls._get_data_from_instance(instance)
         controls = (
             FormControl.from_field(name=name, field=field, value=data.get(name, ""))
             for n, (name, field) in enumerate(model.model_fields.items())
         )
-        return cls(*controls, model=model, instance=instance, **kwargs)
+        return cls(*controls, model=model, instance=instance, data=data, **kwargs)
 
     @classmethod
     def _get_data_from_instance(cls, instance: BaseModel | None) -> dict[str, Any]:

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -32,9 +32,9 @@ class FormControl(Static):
         self,
         id: str,
         label: str,
-        value: str = "",
+        value: Any = "",
         placeholder: str = "",
-        default: str = "",
+        default: Any = "",
         error: ErrorDetails | None = None,
         password: bool = False,
         **kwargs,
@@ -42,9 +42,9 @@ class FormControl(Static):
         """Construct a form control widget."""
         super().__init__(id=id, **kwargs)
         self.label = label
-        self.value = value
+        self.value = "" if value is None else str(value)
         self.placeholder = placeholder
-        self.default = default
+        self.default = "" if default is None else str(default)
         self.password = password
         self.error = error
 

--- a/dokli/tui/screens/generic/__init__.py
+++ b/dokli/tui/screens/generic/__init__.py
@@ -1,0 +1,1 @@
+"""Generic screens package."""

--- a/dokli/tui/screens/generic/confirm.py
+++ b/dokli/tui/screens/generic/confirm.py
@@ -1,0 +1,54 @@
+"""Generic confirmation screen for mutating actions."""
+
+from typing import TYPE_CHECKING
+
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Header, Label
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class ConfirmScreen(Screen):
+    """Ask for explicit confirmation before running an action.
+
+    Dismisses with ``True`` (confirmed) or ``False`` (cancelled).
+    """
+
+    BINDINGS = [
+        Binding("y", "confirm", "Yes"),
+        Binding("n", "cancel", "No"),
+        Binding("escape", "cancel", "No"),
+    ]
+
+    def __init__(self, title: str, message: str, danger: bool = False, *args, **kwargs) -> None:
+        """Construct the confirmation screen."""
+        super().__init__(*args, **kwargs)
+        self._title = title
+        self._message = message
+        self._danger = danger
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield Label(self._title, id="title", classes="title")
+        yield Label(self._message, id="message")
+        yield Button("Yes", id="yes", variant="error" if self._danger else "primary")
+        yield Button("No", id="no")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle buttons."""
+        if event.button.id == "yes":
+            self.dismiss(True)
+        elif event.button.id == "no":
+            self.dismiss(False)
+
+    def action_confirm(self) -> None:
+        """Confirm the action."""
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        """Cancel the action."""
+        self.dismiss(False)

--- a/dokli/tui/screens/generic/entity_list.py
+++ b/dokli/tui/screens/generic/entity_list.py
@@ -1,0 +1,106 @@
+"""Generic entity list (via ``entity.all``)."""
+
+from typing import TYPE_CHECKING
+
+from textual import log
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Label, ListItem, ListView, LoadingIndicator
+
+from dokli.commands import HTTPError, Response, run_command
+from dokli.config import ConnectionConfig
+from dokli.tui.engine import EntityRegistry, record_subtitle, record_title
+from dokli.tui.screens.generic.record import RecordScreen
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class RecordItem(ListItem):
+    """A record in the entity list."""
+
+    def __init__(self, record: dict, *args, **kwargs) -> None:
+        """Construct a record item."""
+        super().__init__(*args, **kwargs)
+        self.record = record
+
+    def compose(self) -> "ComposeResult":
+        """Compose the widget."""
+        yield Label(record_title(self.record), id="name", classes="title")
+        subtitle = record_subtitle(self.record)
+        if subtitle:
+            yield Label(subtitle, id="subtitle")
+
+
+class EntityListScreen(Screen):
+    """List records of an entity."""
+
+    BINDINGS = [
+        Binding("r", "refresh", "Refresh"),
+        Binding("escape", "cancel", "Back"),
+    ]
+
+    def __init__(
+        self,
+        connection: ConnectionConfig,
+        registry: EntityRegistry,
+        entity_name: str,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Construct the entity list screen."""
+        super().__init__(*args, **kwargs)
+        self.connection = connection
+        self.registry = registry
+        self.entity_name = entity_name
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield ListView(id="records")
+        yield LoadingIndicator(id="loading")
+
+    def on_screen_resume(self, event) -> None:
+        """On screen resume."""
+        self.app.sub_title = f"{self.connection.name} - {self.entity_name}"
+        self._refresh()
+
+    def action_refresh(self) -> None:
+        """Refresh the record list."""
+        self._refresh()
+
+    def _refresh(self) -> None:
+        entity = self.registry.get(self.entity_name)
+        action = entity.get("all") if entity else None
+        if action is None:
+            self.notify(f"'{self.entity_name}' has no 'all' action.", severity="warning")
+            return
+        self.run_worker(self._load(action.route), exclusive=True)
+
+    async def _load(self, route: str) -> None:
+        loading = self.query_one(LoadingIndicator)
+        loading.classes = ""
+        response = run_command(self.connection, method="GET", route=route)
+        match response:
+            case Response():
+                data = response.json()
+                records = data if isinstance(data, list) else data.get("items", [])
+                await self._populate(records)
+            case HTTPError():
+                self.notify(f"API error: {response!r}", severity="error", timeout=10)
+                log("api error", response)
+        loading.classes = "hidden"
+
+    async def _populate(self, records: list[dict]) -> None:
+        list_view = self.query_one(ListView)
+        await list_view.clear()
+        list_view.extend([RecordItem(record, id=f"record__{n}") for n, record in enumerate(records)])
+        list_view.focus()
+
+    def on_list_view_selected(self, event) -> None:
+        """Open the selected record."""
+        if isinstance(event.item, RecordItem):
+            self.app.push_screen(
+                RecordScreen(self.connection, self.registry, self.entity_name, event.item.record, classes="Entities")
+            )

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -12,8 +12,9 @@ from textual.widgets import Button, Footer, Header
 
 from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
-from dokli.tui.engine import EntityAction, build_form_model
+from dokli.tui.engine import DESTRUCTIVE_VERBS, EntityAction, build_form_model
 from dokli.tui.forms import Form
+from dokli.tui.screens.generic.confirm import ConfirmScreen
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -93,7 +94,19 @@ class ActionFormScreen(Screen):
                 else raw_value
             )
             body[key] = value
-        self._execute(body)
+        self._confirm_execute(body)
+
+    def _confirm_execute(self, body: dict) -> None:
+        summary = ", ".join(f"{key}={value}" for key, value in body.items())
+        danger = self.action.verb in DESTRUCTIVE_VERBS
+        self.app.push_screen(
+            ConfirmScreen(
+                title=f"Run {self.action.route}?",
+                message=summary,
+                danger=danger,
+            ),
+            callback=lambda confirmed: self._execute(body) if confirmed else None,
+        )
 
     def _execute(self, body: dict) -> None:
         log("submitting", self.action.route, body)

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -1,0 +1,113 @@
+"""Generic action form (built from an OpenAPI request body schema)."""
+
+from typing import TYPE_CHECKING
+
+import httpx
+from pydantic import SecretBytes, SecretStr
+from textual import log
+from textual.binding import Binding
+from textual.message import Message
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Header
+
+from dokli.api_client import APIClient
+from dokli.config import ConnectionConfig
+from dokli.tui.engine import EntityAction, build_form_model
+from dokli.tui.forms import Form
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class ActionFormScreen(Screen):
+    """Render an action form and submit it."""
+
+    BINDINGS = [
+        Binding("ctrl+s", "submit", "Submit"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    class Submitted(Message):
+        """The form was submitted successfully."""
+
+        def __init__(self, route: str, response: httpx.Response) -> None:
+            """Construct the message."""
+            super().__init__()
+            self.route = route
+            self.response = response
+
+    def __init__(
+        self,
+        connection: ConnectionConfig,
+        action: EntityAction,
+        record: dict | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Construct the action form screen."""
+        super().__init__(*args, **kwargs)
+        self.connection = connection
+        self.action = action
+        self.record = record or {}
+        model = build_form_model(action.request_schema, name=f"{action.route}Form")
+        prefill = {key: value for key, value in self.record.items() if key in model.model_fields}
+        self.form = Form.from_model(model, data=prefill, classes="action-form")
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield self.form
+        yield Button("Submit", id="submit", variant="primary")
+        yield Button("Cancel", id="cancel")
+
+    def on_screen_resume(self, event) -> None:
+        """On screen resume."""
+        self.app.sub_title = f"{self.connection.name} - {self.action.route}"
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle buttons."""
+        if event.button.id == "submit":
+            self.action_submit()
+        elif event.button.id == "cancel":
+            self.action_cancel()
+
+    def action_submit(self) -> None:
+        """Validate and submit the form."""
+        if not self.form.validate():
+            self.notify("Fix the highlighted fields.", severity="warning")
+            return
+        data = self.form.cleaned_data or {}
+        required = self.action.request_schema.get("required", [])
+        missing = [name for name in required if not data.get(name)]
+        if missing:
+            self.notify(f"Missing required: {', '.join(missing)}", severity="error", timeout=10)
+            return
+        body = {}
+        for key, raw_value in data.items():
+            if raw_value in ("", None):
+                continue
+            value = (
+                raw_value.get_secret_value()
+                if isinstance(raw_value, SecretStr | SecretBytes)
+                else raw_value
+            )
+            body[key] = value
+        self._execute(body)
+
+    def _execute(self, body: dict) -> None:
+        log("submitting", self.action.route, body)
+        client = APIClient(self.connection)
+        try:
+            response = client.request(self.action.method, self.action.route, {"body": body})
+        except httpx.HTTPError as err:
+            self.notify(f"API error: {err}", severity="error", timeout=10)
+            log("api error", err)
+            return
+        self.post_message(self.Submitted(self.action.route, response))
+        self.notify(f"{self.action.route} OK")
+        self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        """Cancel the form."""
+        self.dismiss(None)

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -78,7 +78,7 @@ class ActionFormScreen(Screen):
             self.notify("Fix the highlighted fields.", severity="warning")
             return
         data = self.form.cleaned_data or {}
-        required = self.action.request_schema.get("required", [])
+        required = [name for name in self.action.request_schema.get("required", []) if name in self.form.fields]
         missing = [name for name in required if not data.get(name)]
         if missing:
             self.notify(f"Missing required: {', '.join(missing)}", severity="error", timeout=10)

--- a/dokli/tui/screens/generic/home.py
+++ b/dokli/tui/screens/generic/home.py
@@ -8,7 +8,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Header, Input, Label, ListItem, ListView
 
 from dokli.config import ConnectionConfig
-from dokli.tui.engine.spec import CORE_ENTITIES, EntityRegistry
+from dokli.tui.engine import EntityRegistry
 from dokli.tui.screens.generic.entity_list import EntityListScreen
 
 if TYPE_CHECKING:
@@ -18,16 +18,22 @@ if TYPE_CHECKING:
 class EntityItem(ListItem):
     """An entity in the home list."""
 
-    def __init__(self, name: str, core: bool, *args, **kwargs) -> None:
+    def __init__(self, name: str, path: list[str], *args, **kwargs) -> None:
         """Construct an entity item."""
         super().__init__(*args, **kwargs)
         self.entity_name = name
-        self.core = core
+        self.navigation_path = path
+
+    @property
+    def listable(self) -> bool:
+        """Whether the entity can be listed directly."""
+        return len(self.navigation_path) == 1
 
     def compose(self) -> "ComposeResult":
         """Compose the widget."""
-        yield Label(f"{'●' if self.core else '○'} {self.entity_name}", id="name", classes="title")
-        yield Label("core" if self.core else "discovered", id="meta")
+        yield Label(f"{'●' if self.listable else '○'} {self.entity_name}", id="name", classes="title")
+        if not self.listable:
+            yield Label("via " + " → ".join(self.navigation_path), id="path")
 
 
 class HomeScreen(Screen):
@@ -77,27 +83,27 @@ class HomeScreen(Screen):
         query = ""
         try:
             search = self.query_one("#search", Input)
-            query = search.value.lower()
+            query = search.value.lower().strip()
         except NoMatches:
             pass
         names = self.registry.names()
-        ordered = [name for name in CORE_ENTITIES if name in names] + [
-            name for name in names if name not in CORE_ENTITIES
-        ]
-        filtered = [name for name in ordered if query in name.lower()]
+        matches = [name for name in names if query in name.lower()] if query else self.registry.listable()
+        items = []
+        for name in matches:
+            path = self.registry.navigation_path(name)
+            items.append(EntityItem(name, path, id=f"entity__{name}"))
         list_view = self.query_one("#entities", ListView)
         await list_view.clear()
-        list_view.extend(
-            [
-                EntityItem(name, name in CORE_ENTITIES, id=f"entity__{name}")
-                for name in filtered
-            ]
-        )
+        list_view.extend(items)
         list_view.focus()
 
     def on_list_view_selected(self, event) -> None:
         """Open the selected entity."""
-        if isinstance(event.item, EntityItem):
+        if not isinstance(event.item, EntityItem):
+            return
+        if event.item.listable:
             self.app.push_screen(
                 EntityListScreen(self.connection, self.registry, event.item.entity_name, classes="Entities")
             )
+        else:
+            self.notify(f"{event.item.entity_name} is reached via " + " → ".join(event.item.navigation_path))

--- a/dokli/tui/screens/generic/home.py
+++ b/dokli/tui/screens/generic/home.py
@@ -1,0 +1,100 @@
+"""Generic entity picker (home screen)."""
+
+from typing import TYPE_CHECKING
+
+from textual.binding import Binding
+from textual.css.query import NoMatches
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Input, Label, ListItem, ListView
+
+from dokli.config import ConnectionConfig
+from dokli.tui.engine.spec import CORE_ENTITIES, EntityRegistry
+from dokli.tui.screens.generic.entity_list import EntityListScreen
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class EntityItem(ListItem):
+    """An entity in the home list."""
+
+    def __init__(self, name: str, core: bool, *args, **kwargs) -> None:
+        """Construct an entity item."""
+        super().__init__(*args, **kwargs)
+        self.entity_name = name
+        self.core = core
+
+    def compose(self) -> "ComposeResult":
+        """Compose the widget."""
+        yield Label(f"{'●' if self.core else '○'} {self.entity_name}", id="name", classes="title")
+        yield Label("core" if self.core else "discovered", id="meta")
+
+
+class HomeScreen(Screen):
+    """Entity picker screen."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Back"),
+        Binding("tab", "focus_list", "Focus list"),
+    ]
+
+    def __init__(
+        self,
+        connection: ConnectionConfig,
+        registry: EntityRegistry,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Construct the home screen."""
+        super().__init__(*args, **kwargs)
+        self.connection = connection
+        self.registry = registry
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield Input(placeholder="Search entities...", id="search")
+        yield ListView(id="entities")
+
+    def on_screen_resume(self, event) -> None:
+        """On screen resume."""
+        self.app.sub_title = f"{self.connection.name} - Entities"
+        self._refresh()
+
+    def on_input_changed(self, event) -> None:
+        """Filter the entity list as the user types."""
+        self._refresh()
+
+    def action_focus_list(self) -> None:
+        """Focus the entity list."""
+        self.query_one(ListView).focus()
+
+    def _refresh(self) -> None:
+        query = ""
+        try:
+            search = self.query_one("#search", Input)
+            query = search.value.lower()
+        except NoMatches:
+            pass
+        names = self.registry.names()
+        ordered = [name for name in CORE_ENTITIES if name in names] + [
+            name for name in names if name not in CORE_ENTITIES
+        ]
+        filtered = [name for name in ordered if query in name.lower()]
+        list_view = self.query_one("#entities", ListView)
+        list_view.clear()
+        list_view.extend(
+            [
+                EntityItem(name, name in CORE_ENTITIES, id=f"entity__{name}")
+                for name in filtered
+            ]
+        )
+        list_view.focus()
+
+    def on_list_view_selected(self, event) -> None:
+        """Open the selected entity."""
+        if isinstance(event.item, EntityItem):
+            self.app.push_screen(
+                EntityListScreen(self.connection, self.registry, event.item.entity_name, classes="Entities")
+            )

--- a/dokli/tui/screens/generic/home.py
+++ b/dokli/tui/screens/generic/home.py
@@ -71,6 +71,9 @@ class HomeScreen(Screen):
         self.query_one(ListView).focus()
 
     def _refresh(self) -> None:
+        self.run_worker(self._refresh_entities(), exclusive=True)
+
+    async def _refresh_entities(self) -> None:
         query = ""
         try:
             search = self.query_one("#search", Input)
@@ -83,7 +86,7 @@ class HomeScreen(Screen):
         ]
         filtered = [name for name in ordered if query in name.lower()]
         list_view = self.query_one("#entities", ListView)
-        list_view.clear()
+        await list_view.clear()
         list_view.extend(
             [
                 EntityItem(name, name in CORE_ENTITIES, id=f"entity__{name}")

--- a/dokli/tui/screens/generic/record.py
+++ b/dokli/tui/screens/generic/record.py
@@ -1,0 +1,127 @@
+"""Generic record detail + action picker."""
+
+from typing import TYPE_CHECKING
+
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
+
+from dokli.config import ConnectionConfig
+from dokli.tui.engine import EntityRegistry, classify, field_label, record_id
+from dokli.tui.screens.generic.form import ActionFormScreen
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class FieldRow(Static):
+    """A key/value row."""
+
+    def __init__(self, key: str, value, *args, **kwargs) -> None:
+        """Construct a field row."""
+        super().__init__(*args, **kwargs)
+        self.key = key
+        self.value = value
+
+    def render(self):
+        """Render the row."""
+        value = self.value
+        if isinstance(value, dict | list):
+            value = f"{type(value).__name__} ({len(value)})"
+        return f"[b]{field_label(self.key)}:[/b] {value}"
+
+
+class ActionItem(ListItem):
+    """An action available on the record."""
+
+    def __init__(self, verb: str, action_type: str, *args, **kwargs) -> None:
+        """Construct an action item."""
+        super().__init__(*args, **kwargs)
+        self.verb = verb
+        self.action_type = action_type
+
+    def compose(self) -> "ComposeResult":
+        """Compose the widget."""
+        yield Label(self.verb, id="name", classes="title")
+        yield Label(self.action_type, id="meta")
+
+
+class RecordScreen(Screen):
+    """Show a record and its actions."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Back"),
+    ]
+
+    def __init__(
+        self,
+        connection: ConnectionConfig,
+        registry: EntityRegistry,
+        entity_name: str,
+        record: dict,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Construct the record screen."""
+        super().__init__(*args, **kwargs)
+        self.connection = connection
+        self.registry = registry
+        self.entity_name = entity_name
+        self.record = record
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield Label(self.record_title(), id="title", classes="title")
+        yield VerticalScroll(
+            *(FieldRow(key, value) for key, value in self.record.items()),
+            id="fields",
+        )
+        yield Label("Actions", id="actions-title")
+        yield ListView(id="actions")
+
+    def record_title(self) -> str:
+        """Title of the record."""
+        for key in ("name", "appName", "title"):
+            if self.record.get(key):
+                return str(self.record[key])
+        return str(record_id(self.record, self.entity_name) or self.entity_name)
+
+    def on_screen_resume(self, event) -> None:
+        """On screen resume."""
+        self.app.sub_title = f"{self.connection.name} - {self.entity_name}"
+        self._refresh()
+
+    def _refresh(self) -> None:
+        entity = self.registry.get(self.entity_name)
+        actions = list(entity.actions.values()) if entity else []
+        self._populate_actions(actions)
+
+    def _populate_actions(self, actions) -> None:
+        list_view = self.query_one("#actions", ListView)
+        form_actions = [a for a in actions if classify(a) == "form"]
+        other_actions = [a for a in actions if classify(a) != "form"]
+        list_view.extend(
+            [
+                *(ActionItem(a.verb, "form", id=f"action__{a.verb}") for a in form_actions),
+                *(ActionItem(a.verb, "action", id=f"action__{a.verb}") for a in other_actions),
+            ]
+        )
+        list_view.focus()
+
+    def on_list_view_selected(self, event) -> None:
+        """Run the selected action."""
+        if not isinstance(event.item, ActionItem):
+            return
+        entity = self.registry.get(self.entity_name)
+        action = entity.get(event.item.verb) if entity else None
+        if action is None:
+            return
+        if classify(action) == "form":
+            self.app.push_screen(
+                ActionFormScreen(self.connection, action, record=self.record, classes="Entities")
+            )
+        else:
+            self.notify(f"'{action.verb}' action not implemented yet.", severity="warning")

--- a/dokli/tui/screens/generic/record.py
+++ b/dokli/tui/screens/generic/record.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
 from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.tui.engine import (
+    DESTRUCTIVE_VERBS,
     EntityRegistry,
     classify,
     field_label,
@@ -18,6 +19,7 @@ from dokli.tui.engine import (
     record_id,
     record_title,
 )
+from dokli.tui.screens.generic.confirm import ConfirmScreen
 from dokli.tui.screens.generic.form import ActionFormScreen
 
 if TYPE_CHECKING:
@@ -217,4 +219,38 @@ class RecordScreen(Screen):
                 ActionFormScreen(self.connection, action, record=self.record, classes="Entities")
             )
         else:
-            self.notify(f"'{action.verb}' action not implemented yet.", severity="warning")
+            self._confirm_action(action)
+
+    def _confirm_action(self, action) -> None:
+        """Confirm and run a non-form action (e.g. remove, deploy)."""
+        body = {}
+        schema = action.request_schema
+        if schema.get("properties"):
+            body = {
+                key: value
+                for key, value in self.record.items()
+                if key in schema["properties"] and value is not None
+            }
+        danger = action.verb in DESTRUCTIVE_VERBS
+        title = f"Run {action.route}?"
+        message = ", ".join(f"{key}={value}" for key, value in body.items()) or "(no body)"
+        self.app.push_screen(
+            ConfirmScreen(title=title, message=message, danger=danger),
+            callback=lambda confirmed: self._run_action(action, body) if confirmed else None,
+        )
+
+    def _run_action(self, action, body: dict) -> None:
+        client = APIClient(self.connection)
+        params: dict = {}
+        if body:
+            params["body"] = body
+        try:
+            client.request(action.method, action.route, params)
+        except httpx.HTTPError as err:
+            self.notify(f"API error: {err}", severity="error", timeout=10)
+            return
+        self.notify(f"{action.route} OK")
+        if action.verb in DESTRUCTIVE_VERBS:
+            self.dismiss(None)
+        else:
+            self.action_refresh()

--- a/dokli/tui/screens/generic/record.py
+++ b/dokli/tui/screens/generic/record.py
@@ -92,17 +92,18 @@ class RecordScreen(Screen):
     def on_screen_resume(self, event) -> None:
         """On screen resume."""
         self.app.sub_title = f"{self.connection.name} - {self.entity_name}"
-        self._refresh()
+        self.run_worker(self._refresh(), exclusive=True)
 
-    def _refresh(self) -> None:
+    async def _refresh(self) -> None:
         entity = self.registry.get(self.entity_name)
         actions = list(entity.actions.values()) if entity else []
-        self._populate_actions(actions)
+        await self._populate_actions(actions)
 
-    def _populate_actions(self, actions) -> None:
+    async def _populate_actions(self, actions) -> None:
         list_view = self.query_one("#actions", ListView)
+        await list_view.clear()
         form_actions = [a for a in actions if classify(a) == "form"]
-        other_actions = [a for a in actions if classify(a) != "form"]
+        other_actions = [a for a in actions if classify(a) in ("action",)]
         list_view.extend(
             [
                 *(ActionItem(a.verb, "form", id=f"action__{a.verb}") for a in form_actions),

--- a/dokli/tui/screens/generic/record.py
+++ b/dokli/tui/screens/generic/record.py
@@ -1,14 +1,23 @@
-"""Generic record detail + action picker."""
+"""Generic record detail + child navigation + action picker."""
 
 from typing import TYPE_CHECKING
 
+import httpx
 from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
 
+from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
-from dokli.tui.engine import EntityRegistry, classify, field_label, record_id
+from dokli.tui.engine import (
+    EntityRegistry,
+    classify,
+    field_label,
+    nested_child_entity,
+    record_id,
+    record_title,
+)
 from dokli.tui.screens.generic.form import ActionFormScreen
 
 if TYPE_CHECKING:
@@ -32,6 +41,20 @@ class FieldRow(Static):
         return f"[b]{field_label(self.key)}:[/b] {value}"
 
 
+class ChildItem(ListItem):
+    """A nested child record (drill-down)."""
+
+    def __init__(self, child_entity: str, record: dict, *args, **kwargs) -> None:
+        """Construct a child item."""
+        super().__init__(*args, **kwargs)
+        self.child_entity = child_entity
+        self.record = record
+
+    def compose(self) -> "ComposeResult":
+        """Compose the widget."""
+        yield Label(f"{self.child_entity} · {record_title(self.record)}", id="name", classes="title")
+
+
 class ActionItem(ListItem):
     """An action available on the record."""
 
@@ -48,9 +71,10 @@ class ActionItem(ListItem):
 
 
 class RecordScreen(Screen):
-    """Show a record and its actions."""
+    """Show a record, its nested children and its actions."""
 
     BINDINGS = [
+        Binding("r", "refresh", "Refresh"),
         Binding("escape", "cancel", "Back"),
     ]
 
@@ -75,10 +99,10 @@ class RecordScreen(Screen):
         yield Header()
         yield Footer()
         yield Label(self.record_title(), id="title", classes="title")
-        yield VerticalScroll(
-            *(FieldRow(key, value) for key, value in self.record.items()),
-            id="fields",
-        )
+        yield Label("Children", id="children-title")
+        yield ListView(id="children")
+        yield Label("Fields", id="fields-title")
+        yield VerticalScroll(id="fields")
         yield Label("Actions", id="actions-title")
         yield ListView(id="actions")
 
@@ -92,28 +116,96 @@ class RecordScreen(Screen):
     def on_screen_resume(self, event) -> None:
         """On screen resume."""
         self.app.sub_title = f"{self.connection.name} - {self.entity_name}"
-        self.run_worker(self._refresh(), exclusive=True)
+        self.action_refresh()
 
-    async def _refresh(self) -> None:
+    def action_refresh(self) -> None:
+        """Refresh the record detail."""
+        self.run_worker(self._load(), exclusive=True)
+
+    async def _load(self) -> None:
+        entity = self.registry.get(self.entity_name)
+        action = entity.get("one") if entity else None
+        if action is not None:
+            params = self._action_params(action)
+            if params:
+                client = APIClient(self.connection)
+                try:
+                    response = client.request("GET", action.route, params)
+                    self.record = response.json()
+                except httpx.HTTPError as err:
+                    self.notify(f"API error: {err}", severity="error", timeout=10)
+        await self._refresh_view()
+
+    def _action_params(self, action) -> dict:
+        params = {}
+        for param in action.param_names:
+            value = self.record.get(param) or record_id(self.record, self.entity_name)
+            if value:
+                params[param] = value
+        return params
+
+    async def _refresh_view(self) -> None:
+        await self._render_children()
+        await self._render_fields()
+        await self._render_actions()
+
+    def _collect_children(self) -> list[tuple[str, dict]]:
+        children = []
+        for key, records in self.record.items():
+            child_entity = nested_child_entity(key)
+            if not child_entity or not isinstance(records, list):
+                continue
+            for record in records:
+                if isinstance(record, dict):
+                    children.append((child_entity, record))
+        return children
+
+    async def _render_children(self) -> None:
+        children = self._collect_children()
+        list_view = self.query_one("#children", ListView)
+        await list_view.clear()
+        list_view.extend(
+            [
+                ChildItem(entity, record, id=f"child__{n}")
+                for n, (entity, record) in enumerate(children)
+            ]
+        )
+        self.query_one("#children-title").display = bool(children)
+        if children:
+            list_view.focus()
+
+    async def _render_fields(self) -> None:
+        container = self.query_one("#fields", VerticalScroll)
+        container.remove_children()
+        await container.mount(*(FieldRow(key, value) for key, value in self.record.items()))
+
+    async def _render_actions(self) -> None:
         entity = self.registry.get(self.entity_name)
         actions = list(entity.actions.values()) if entity else []
-        await self._populate_actions(actions)
-
-    async def _populate_actions(self, actions) -> None:
         list_view = self.query_one("#actions", ListView)
         await list_view.clear()
         form_actions = [a for a in actions if classify(a) == "form"]
-        other_actions = [a for a in actions if classify(a) in ("action",)]
+        other_actions = [a for a in actions if classify(a) == "action"]
         list_view.extend(
             [
                 *(ActionItem(a.verb, "form", id=f"action__{a.verb}") for a in form_actions),
                 *(ActionItem(a.verb, "action", id=f"action__{a.verb}") for a in other_actions),
             ]
         )
-        list_view.focus()
 
     def on_list_view_selected(self, event) -> None:
-        """Run the selected action."""
+        """Navigate or run the selected action."""
+        if isinstance(event.item, ChildItem):
+            self.app.push_screen(
+                RecordScreen(
+                    self.connection,
+                    self.registry,
+                    event.item.child_entity,
+                    event.item.record,
+                    classes="Entities",
+                )
+            )
+            return
         if not isinstance(event.item, ActionItem):
             return
         entity = self.registry.get(self.entity_name)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,86 @@
+"""TUI smoke tests."""
+
+import asyncio
+
+from dokli.config import Config, ConnectionConfig
+from dokli.tui.app import DokliApp
+from dokli.tui.screens.generic.home import EntityItem, HomeScreen
+
+FAKE_SCHEMA = {
+    "paths": {
+        "/project.all": {"get": {}},
+        "/project.one": {
+            "get": {"parameters": [{"name": "projectId", "in": "query", "required": True}]}
+        },
+        "/project.create": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                                "required": ["name"],
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/redis.all": {"get": {}},
+    }
+}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _select_connection(app, pilot):
+    list_view = app.screen.query_one("#connections-list")
+    list_view.index = 0
+    list_view.focus()
+    await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+def test_connection_selection_opens_home(mocker):
+    """We expect selecting a connection to open the entity browser."""
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    config = Config(connections=[connection])
+    client = mocker.Mock()
+    client.schema = FAKE_SCHEMA
+    mocker.patch("dokli.tui.app.APIClient", return_value=client)
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _select_connection(app, pilot)
+            assert isinstance(app.screen, HomeScreen)
+
+    _run(main())
+
+
+def test_home_lists_core_entities(mocker):
+    """We expect the home screen to list project and redis as core entities."""
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    config = Config(connections=[connection])
+    client = mocker.Mock()
+    client.schema = FAKE_SCHEMA
+    mocker.patch("dokli.tui.app.APIClient", return_value=client)
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _select_connection(app, pilot)
+            items = [
+                child for child in app.screen.query_one("#entities").children if isinstance(child, EntityItem)
+            ]
+            labels = [item.query_one("#name").renderable for item in items]
+            assert any("project" in label for label in labels)
+            assert any("redis" in label for label in labels)
+
+    _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -92,11 +92,15 @@ def test_record_screen_resume_does_not_duplicate(mocker):
     """We expect resuming a record screen (e.g. after closing a form) not to duplicate actions."""
     connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
     config = Config(connections=[connection])
-    client = mocker.Mock()
-    client.schema = FAKE_SCHEMA
-    mocker.patch("dokli.tui.app.APIClient", return_value=client)
+    mocker.patch("dokli.tui.app.APIClient")
     registry = parse_spec(FAKE_SCHEMA)
     record = {"projectId": "p1", "name": "app"}
+
+    response = mocker.Mock()
+    response.json.return_value = record
+    client = mocker.Mock()
+    client.request.return_value = response
+    mocker.patch("dokli.tui.screens.generic.record.APIClient", return_value=client)
 
     async def main():
         app = DokliApp(config=config)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -6,6 +6,8 @@ from dokli.config import Config, ConnectionConfig
 from dokli.tui.app import DokliApp
 from dokli.tui.engine import build_form_model, parse_spec
 from dokli.tui.forms import Form
+from dokli.tui.screens.generic.confirm import ConfirmScreen
+from dokli.tui.screens.generic.form import ActionFormScreen
 from dokli.tui.screens.generic.home import EntityItem, HomeScreen
 from dokli.tui.screens.generic.record import ActionItem, RecordScreen
 
@@ -44,6 +46,37 @@ def test_form_prefills_from_data():
     model = build_form_model({"properties": {"name": {"type": "string"}}})
     form = Form.from_model(model, data={"name": "prefilled"})
     assert form.fields["name"].value == "prefilled"
+
+
+def test_form_control_coerces_non_string_values():
+    """We expect boolean/number prefill values not to crash the input."""
+    model = build_form_model({"properties": {"autoDeploy": {"type": "boolean"}}})
+    form = Form.from_model(model, data={"autoDeploy": True})
+    assert form.fields["autoDeploy"].value == "True"
+
+
+def test_form_submit_asks_confirmation(mocker):
+    """We expect submitting a form to require explicit confirmation first."""
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    config = Config(connections=[connection])
+    mocker.patch("dokli.tui.app.APIClient")
+    mocker.patch("dokli.tui.screens.generic.form.APIClient")
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("project").get("create")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            screen = ActionFormScreen(connection, action)
+            app.install_screen(screen, name="form")
+            app.push_screen("form")
+            await pilot.pause()
+            screen.form.fields["name"].value = "test"
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmScreen)
+
+    _run(main())
 
 
 async def _select_connection(app, pilot):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,7 +4,9 @@ import asyncio
 
 from dokli.config import Config, ConnectionConfig
 from dokli.tui.app import DokliApp
+from dokli.tui.engine import parse_spec
 from dokli.tui.screens.generic.home import EntityItem, HomeScreen
+from dokli.tui.screens.generic.record import ActionItem, RecordScreen
 
 FAKE_SCHEMA = {
     "paths": {
@@ -82,5 +84,37 @@ def test_home_lists_core_entities(mocker):
             labels = [item.query_one("#name").renderable for item in items]
             assert any("project" in label for label in labels)
             assert any("redis" in label for label in labels)
+
+    _run(main())
+
+
+def test_record_screen_resume_does_not_duplicate(mocker):
+    """We expect resuming a record screen (e.g. after closing a form) not to duplicate actions."""
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    config = Config(connections=[connection])
+    client = mocker.Mock()
+    client.schema = FAKE_SCHEMA
+    mocker.patch("dokli.tui.app.APIClient", return_value=client)
+    registry = parse_spec(FAKE_SCHEMA)
+    record = {"projectId": "p1", "name": "app"}
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            screen = RecordScreen(connection, registry, "project", record)
+            app.install_screen(screen, name="record")
+            app.push_screen("record")
+            await pilot.pause()
+            screen.on_screen_resume(None)
+            await pilot.pause()
+            screen.on_screen_resume(None)
+            await pilot.pause()
+            actions = [
+                child
+                for child in screen.query_one("#actions").children
+                if isinstance(child, ActionItem)
+            ]
+            verbs = [action.verb for action in actions]
+            assert verbs == ["create"]
 
     _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,7 +4,8 @@ import asyncio
 
 from dokli.config import Config, ConnectionConfig
 from dokli.tui.app import DokliApp
-from dokli.tui.engine import parse_spec
+from dokli.tui.engine import build_form_model, parse_spec
+from dokli.tui.forms import Form
 from dokli.tui.screens.generic.home import EntityItem, HomeScreen
 from dokli.tui.screens.generic.record import ActionItem, RecordScreen
 
@@ -36,6 +37,13 @@ FAKE_SCHEMA = {
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+def test_form_prefills_from_data():
+    """We expect Form.from_model to prefill controls from the data kwarg."""
+    model = build_form_model({"properties": {"name": {"type": "string"}}})
+    form = Form.from_model(model, data={"name": "prefilled"})
+    assert form.fields["name"].value == "prefilled"
 
 
 async def _select_connection(app, pilot):

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -181,6 +181,23 @@ class TestBuildFormModel:
         )
         assert model(mode="dev").mode == "dev"
 
+    def test_filters_read_only_fields(self):
+        """We expect server-managed fields to be filtered from the form."""
+        model = build_form_model(
+            {
+                "properties": {
+                    "name": {"type": "string"},
+                    "createdAt": {"type": "string"},
+                    "organizationId": {"type": "string"},
+                    "applicationStatus": {"type": "string"},
+                }
+            }
+        )
+        assert "name" in model.model_fields
+        assert "createdAt" not in model.model_fields
+        assert "organizationId" not in model.model_fields
+        assert "applicationStatus" not in model.model_fields
+
 
 class TestIntrospect:
     """Introspection helpers tests."""

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -10,6 +10,7 @@ from dokli.tui.engine import (
     classify,
     field_label,
     infer_columns,
+    nested_child_entity,
     parse_spec,
     record_id,
     record_title,
@@ -42,6 +43,43 @@ def _spec() -> dict:
                 }
             },
             "/project.remove": {"post": {}},
+            "/environment.create": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "projectId": {"type": "string"},
+                                        "name": {"type": "string"},
+                                    },
+                                    "required": ["name", "projectId"],
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/compose.create": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "environmentId": {"type": "string"},
+                                        "serverId": {"type": "string"},
+                                        "name": {"type": "string"},
+                                    },
+                                    "required": ["name", "environmentId"],
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "/compose.deploy": {"post": {}},
         }
     }
@@ -56,9 +94,35 @@ class TestParseSpec:
         assert isinstance(registry, EntityRegistry)
         assert "project" in registry.names()
         assert "compose" in registry.names()
+        assert "environment" in registry.names()
         project = registry.get("project")
         assert isinstance(project, Entity)
         assert set(project.actions) == {"all", "one", "create", "remove"}
+
+    def test_listable(self):
+        """We expect entities with an all action to be listable."""
+        registry = parse_spec(_spec())
+        assert registry.listable() == ["project"]
+        assert registry.get("compose").listable is False
+
+    def test_parent_entity_inference(self):
+        """We expect the parent to be inferred from create foreign keys."""
+        registry = parse_spec(_spec())
+        assert registry.get("environment").parent_entity == "project"
+        assert registry.get("compose").parent_entity == "environment"
+        assert registry.get("project").parent_entity is None
+
+    def test_navigation_path(self):
+        """We expect the ancestor chain to be computed."""
+        registry = parse_spec(_spec())
+        assert registry.navigation_path("compose") == ["project", "environment", "compose"]
+        assert registry.navigation_path("project") == ["project"]
+
+    def test_nested_child_entity(self):
+        """We expect nested array keys to map to child entities."""
+        assert nested_child_entity("environments") == "environment"
+        assert nested_child_entity("compose") == "compose"
+        assert nested_child_entity("unknown") is None
 
     def test_action_details(self):
         """We expect action metadata to be extracted."""

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -1,0 +1,144 @@
+"""TUI engine tests (spec parsing, schemas, introspection)."""
+
+from pydantic import SecretStr
+
+from dokli.tui.engine import (
+    Entity,
+    EntityAction,
+    EntityRegistry,
+    build_form_model,
+    classify,
+    field_label,
+    infer_columns,
+    parse_spec,
+    record_id,
+    record_title,
+)
+
+
+def _spec() -> dict:
+    return {
+        "paths": {
+            "/project.all": {"get": {"summary": "List projects"}},
+            "/project.one": {
+                "get": {"parameters": [{"name": "projectId", "in": "query", "required": True}]}
+            },
+            "/project.create": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "description": {"type": "string"},
+                                    },
+                                    "required": ["name"],
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/project.remove": {"post": {}},
+            "/compose.deploy": {"post": {}},
+        }
+    }
+
+
+class TestParseSpec:
+    """Spec parsing tests."""
+
+    def test_parses_entities_and_actions(self):
+        """We expect entities and actions to be discovered."""
+        registry = parse_spec(_spec())
+        assert isinstance(registry, EntityRegistry)
+        assert "project" in registry.names()
+        assert "compose" in registry.names()
+        project = registry.get("project")
+        assert isinstance(project, Entity)
+        assert set(project.actions) == {"all", "one", "create", "remove"}
+
+    def test_action_details(self):
+        """We expect action metadata to be extracted."""
+        registry = parse_spec(_spec())
+        create = registry.get("project").get("create")
+        assert isinstance(create, EntityAction)
+        assert create.method == "POST"
+        assert create.route == "project.create"
+        assert create.request_schema["required"] == ["name"]
+        one = registry.get("project").get("one")
+        assert one.param_names == ["projectId"]
+
+
+class TestClassify:
+    """Verb classification tests."""
+
+    def _action(self, verb: str, method: str = "GET") -> EntityAction:
+        return EntityAction(verb=verb, method=method, route=f"x.{verb}")
+
+    def test_classification(self):
+        """We expect verbs to map to generic interactions."""
+        assert classify(self._action("all")) == "list"
+        assert classify(self._action("one")) == "detail"
+        assert classify(self._action("create", "POST")) == "form"
+        assert classify(self._action("update", "POST")) == "form"
+        assert classify(self._action("saveEnvironment", "POST")) == "form"
+        assert classify(self._action("remove", "POST")) == "action"
+        assert classify(self._action("deploy", "POST")) == "action"
+
+
+class TestBuildFormModel:
+    """Schema → form model tests."""
+
+    def test_model_fields(self):
+        """We expect a model with the schema's fields."""
+        model = build_form_model(
+            {
+                "properties": {"name": {"type": "string"}, "count": {"type": "integer"}},
+                "required": ["name"],
+            }
+        )
+        instance = model(name="x", count=3)
+        assert instance.name == "x"
+        assert instance.count == 3
+
+    def test_secret_fields(self):
+        """We expect secret-like fields to be SecretStr."""
+        model = build_form_model({"properties": {"databasePassword": {"type": "string"}}})
+        instance = model(databasePassword="hunter2")
+        assert isinstance(instance.databasePassword, SecretStr)
+
+    def test_enum_fields(self):
+        """We expect string enums to be Literal."""
+        model = build_form_model(
+            {"properties": {"mode": {"type": "string", "enum": ["dev", "prod"]}}}
+        )
+        assert model(mode="dev").mode == "dev"
+
+
+class TestIntrospect:
+    """Introspection helpers tests."""
+
+    def test_field_label(self):
+        """We expect camelCase to be turned into a title."""
+        assert field_label("composeStatus") == "Compose Status"
+        assert field_label("name") == "Name"
+
+    def test_record_id(self):
+        """We expect the entity-specific id to be found."""
+        assert record_id({"projectId": "p1", "name": "x"}, "project") == "p1"
+        assert record_id({"id": "p1"}) == "p1"
+
+    def test_record_title(self):
+        """We expect a sensible title for a record."""
+        assert record_title({"name": "myapp"}) == "myapp"
+        assert record_title({"projectId": "p1"}) == "p1"
+
+    def test_infer_columns(self):
+        """We expect preferred columns to be picked."""
+        records = [{"projectId": "p1", "name": "x", "description": "d", "createdAt": "t", "env": ""}]
+        columns = infer_columns(records, "project")
+        assert "name" in columns
+        assert "createdAt" not in columns


### PR DESCRIPTION
Part of #42 — Phase R0 of the generative TUI: an interface auto-generated from the OpenAPI document.

## What's in this PR

- **`dokli/tui/engine/`**:
  - `spec.py` — parses the OpenAPI document into an `EntityRegistry` (`entity.action` convention) with verb classification (`all`→list, `one`→detail, `create/update/save*`→form, `remove/delete`→action, others→action) and a curated `CORE_ENTITIES` list.
  - `schemas.py` — builds a pydantic model from a request body schema (reuses the existing generic `Form` widget); secret-like fields become `SecretStr`, string enums become `Literal`.
  - `introspect.py` — response bodies have no schema in Dokploy's OpenAPI, so list/detail derive titles, ids and columns from the live data.
- **`dokli/tui/screens/generic/`**:
  - `home.py` — core entities first + a search filter over all discovered entities.
  - `entity_list.py` — records via `entity.all`.
  - `record.py` — key/value detail + available actions (form actions open the action form).
  - `form.py` — action form from the request schema, prefilled from the record, secret values unwrapped before POST, executed via `APIClient`.
- **`app.py`** — selecting a connection now opens the entity browser (replaces the old Projects screen, which was broken against the modern API shape).

## Verified

- End-to-end against `dokploy.meche.lan`: connection → 50 entities listed, 12 core first.
- `make lint` ✓, `make test` → 80 passed (engine unit tests + 2 textual pilot smoke tests).

Next: R1 (rich form controls: Select/Switch/TextArea + wizard mode), R2 (actions/results/confirm), R3 (connections persistence + Help + command palette).
