### PR TITLE
Generative TUI (R1): rich form controls + wizard mode

### DIFF
--- a/dokli/tui/engine/schemas.py
+++ b/dokli/tui/engine/schemas.py
@@ -55,7 +55,16 @@ def _annotation_for(field_name: str, prop: dict[str, Any]) -> Any:
         return SecretStr
     if "enum" in prop and prop.get("type") == "string":
         return Literal[tuple(prop["enum"])]
-    return JSON_TO_ANNOTATION.get(str(prop.get("type")), str)
+    json_type = prop.get("type")
+    if json_type is None and isinstance(prop.get("anyOf"), list):
+        for sub in prop["anyOf"]:
+            if not sub.get("type") or sub.get("type") == "null":
+                continue
+            if sub.get("type") == "string" and "enum" in sub:
+                return Literal[tuple(sub["enum"])]
+            json_type = sub.get("type")
+            break
+    return JSON_TO_ANNOTATION.get(str(json_type), str)
 
 
 def _label_for(field_name: str) -> str:

--- a/dokli/tui/engine/schemas.py
+++ b/dokli/tui/engine/schemas.py
@@ -27,6 +27,19 @@ READ_ONLY_FIELDS = {
     "refreshToken",
 }
 
+# String fields that are expected to hold multi-line content.
+MULTILINE_FIELDS = {
+    "description",
+    "env",
+    "composeFile",
+    "command",
+    "notes",
+    "buildArgs",
+    "buildSecrets",
+    "previewEnv",
+    "dockerCompose",
+}
+
 
 def build_form_model(schema: dict, name: str = "ActionForm") -> type[BaseModel]:
     """Build a pydantic model from an OpenAPI request body schema.
@@ -46,7 +59,11 @@ def build_form_model(schema: dict, name: str = "ActionForm") -> type[BaseModel]:
         if "enum" in prop:
             options = ", ".join(str(value) for value in prop["enum"])
             description = f"{description} [{options}]" if description else f"Options: {options}"
-        fields[field_name] = (annotation | None, Field(None, title=label, description=description))
+        extra: dict[str, Any] | None = {"multiline": True} if field_name in MULTILINE_FIELDS else None
+        fields[field_name] = (
+            annotation | None,
+            Field(None, title=label, description=description, json_schema_extra=extra),
+        )
     return create_model(name, **fields)
 
 

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -83,12 +83,16 @@ class FormControl(Static):
             placeholder=field.description or "",
         )
         base.update(kwargs)
+        extra = getattr(field, "json_schema_extra", None) or {}
+        value = kwargs.get("value", "")
         if annotation is bool:
             return SwitchControl(id=name, **base)
         if get_origin(annotation) is Literal:
             return SelectControl(id=name, options=list(get_args(annotation)), **base)
         if annotation in (list, dict):
-            return TextAreaControl(id=name, **base)
+            return TextAreaControl(id=name, parse_json=True, **base)
+        if annotation is str and (extra.get("multiline") or (isinstance(value, str) and "\n" in value)):
+            return TextAreaControl(id=name, parse_json=False, **base)
         return TextControl(id=name, password=annotation in (SecretStr, SecretBytes), **base)
 
     def watch_error(self, old_value: ErrorDetails | None, new_value: ErrorDetails | None) -> None:
@@ -203,13 +207,14 @@ class SwitchControl(FormControl):
 
 
 class TextAreaControl(FormControl):
-    """A JSON text area for object/array fields."""
+    """A text area for multi-line strings or JSON objects/arrays."""
 
-    def __init__(self, id: str, value: Any = "", **kwargs) -> None:
+    def __init__(self, id: str, value: Any = "", parse_json: bool = True, **kwargs) -> None:
         """Construct a text area control."""
         if isinstance(value, dict | list):
             value = json.dumps(value)
         super().__init__(id=id, value=value, **kwargs)
+        self.parse_json = parse_json
 
     def compose(self) -> "ComposeResult":
         """Yield the widgets."""
@@ -230,7 +235,9 @@ class TextAreaControl(FormControl):
         self.value = event.text_area.text
 
     def get_data(self) -> Any:
-        """Parse the JSON text into an object/array."""
+        """Parse JSON when the field is an object/array, otherwise return the text."""
+        if not self.parse_json:
+            return self.value
         try:
             return json.loads(self.value)
         except (json.JSONDecodeError, TypeError):

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -2,7 +2,8 @@
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from types import NoneType, UnionType
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, Union, get_args, get_origin
 
 from pydantic import BaseModel, SecretBytes, SecretStr, ValidationError
 from pydantic_core import ErrorDetails
@@ -10,7 +11,7 @@ from textual.containers import Container
 from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widgets import Input, Label, Static
+from textual.widgets import Input, Label, Select, Static, Switch, TextArea
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -19,13 +20,23 @@ if TYPE_CHECKING:
 M = TypeVar("M", bound=BaseModel)
 
 
+def _core_annotation(annotation: Any) -> Any:
+    """Strip ``None`` from an ``X | None`` union annotation."""
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        non_none = [arg for arg in get_args(annotation) if arg is not NoneType]
+        if len(non_none) == 1:
+            return non_none[0]
+    return annotation
+
+
 class FormControl(Static):
-    """Form control widget."""
+    """Base form control widget."""
 
     label = reactive("")
-    value = reactive("")
+    value: reactive[Any] = reactive("")
     placeholder = reactive("")
-    default = reactive("")
+    default: reactive[Any] = reactive("")
     error: reactive[ErrorDetails | None] = reactive(None)
 
     def __init__(
@@ -36,30 +47,22 @@ class FormControl(Static):
         placeholder: str = "",
         default: Any = "",
         error: ErrorDetails | None = None,
-        password: bool = False,
         **kwargs,
     ) -> None:
         """Construct a form control widget."""
         super().__init__(id=id, **kwargs)
         self.label = label
-        self.value = "" if value is None else str(value)
+        self.value = value if value is not None else ""
         self.placeholder = placeholder
-        self.default = "" if default is None else str(default)
-        self.password = password
+        self.default = default if default is not None else ""
         self.error = error
 
     def compose(self) -> "ComposeResult":
-        """Yield children widgets."""
+        """Yield the label and error label (inputs are added by subclasses)."""
         yield Label(
             self.label,
             id=f"{self.id}-label",
             classes="hidden form-label" if not self.label else "form-label",
-        )
-        yield Input(
-            self.value,
-            id=f"{self.id}-input",
-            placeholder=self.placeholder,
-            password=self.password,
         )
         yield Label(
             str(self.error) if self.error else "ERRORR",
@@ -67,26 +70,26 @@ class FormControl(Static):
             classes="error-msg",
         )
 
+    def get_data(self) -> Any:
+        """The value to submit for this control."""
+        return self.value
+
     @staticmethod
     def from_field(name, field, **kwargs) -> "FormControl":
         """Construct a form control from a pydantic field."""
-        return FormControl(
-            id=name,
+        annotation = _core_annotation(field.annotation)
+        base = dict(
             label=field.title if field.title else name.replace("_", " ").title(),
             placeholder=field.description or "",
-            password=field.annotation in (SecretStr, SecretBytes),
-            **kwargs,
         )
-
-    def watch_value(self, old_value: str, new_value: str) -> None:
-        """Watch value changes."""
-        self.value = new_value
-        try:
-            input = self.query_one(f"#{self.id}-input")
-            assert isinstance(input, Input)
-            input.value = new_value
-        except NoMatches:
-            pass
+        base.update(kwargs)
+        if annotation is bool:
+            return SwitchControl(id=name, **base)
+        if get_origin(annotation) is Literal:
+            return SelectControl(id=name, options=list(get_args(annotation)), **base)
+        if annotation in (list, dict):
+            return TextAreaControl(id=name, **base)
+        return TextControl(id=name, password=annotation in (SecretStr, SecretBytes), **base)
 
     def watch_error(self, old_value: ErrorDetails | None, new_value: ErrorDetails | None) -> None:
         """Watch error changes."""
@@ -98,10 +101,6 @@ class FormControl(Static):
         except NoMatches:
             pass
 
-    def on_input_changed(self, event: Input.Changed) -> None:
-        """On input changed."""
-        self.value = event.value
-
     def reset(self, reset_classes=True, reset_value=True, reset_error=True) -> None:
         """Reset."""
         if reset_value:
@@ -110,6 +109,132 @@ class FormControl(Static):
             self.classes = []
         if reset_error:
             self.error = None
+
+
+class TextControl(FormControl):
+    """A single-line text/number/password input."""
+
+    def __init__(self, id: str, value: Any = "", password: bool = False, **kwargs) -> None:
+        """Construct a text control."""
+        super().__init__(id=id, value=value, **kwargs)
+        self.password = password
+
+    def compose(self) -> "ComposeResult":
+        """Yield the widgets."""
+        yield from super().compose()
+        yield Input(
+            "" if self.value in ("", None) else str(self.value),
+            id=f"{self.id}-input",
+            placeholder=self.placeholder,
+            password=self.password,
+        )
+
+    def watch_value(self, old_value: Any, new_value: Any) -> None:
+        """Watch value changes."""
+        try:
+            input = self.query_one(f"#{self.id}-input")
+            assert isinstance(input, Input)
+            input.value = "" if new_value in ("", None) else str(new_value)
+        except NoMatches:
+            pass
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """On input changed."""
+        self.value = event.value
+
+
+class SelectControl(FormControl):
+    """A dropdown for string enums."""
+
+    def __init__(self, id: str, options: list[str], value: Any = "", **kwargs) -> None:
+        """Construct a select control."""
+        super().__init__(id=id, value=value, **kwargs)
+        self.options = options
+
+    def compose(self) -> "ComposeResult":
+        """Yield the widgets."""
+        yield from super().compose()
+        current = self.value if self.value in self.options else Select.BLANK
+        yield Select(
+            [(str(option), option) for option in self.options],
+            value=current,
+            prompt="Select...",
+            id=f"{self.id}-input",
+        )
+
+    def watch_value(self, old_value: Any, new_value: Any) -> None:
+        """Watch value changes."""
+        try:
+            select = self.query_one(f"#{self.id}-input")
+            assert isinstance(select, Select)
+            select.value = new_value if new_value in self.options else Select.BLANK
+        except NoMatches:
+            pass
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """On select changed."""
+        self.value = "" if event.value is Select.BLANK else event.value
+
+
+class SwitchControl(FormControl):
+    """A boolean toggle."""
+
+    def compose(self) -> "ComposeResult":
+        """Yield the widgets."""
+        yield from super().compose()
+        yield Switch(value=bool(self.value), id=f"{self.id}-input")
+
+    def watch_value(self, old_value: Any, new_value: Any) -> None:
+        """Watch value changes."""
+        try:
+            switch = self.query_one(f"#{self.id}-input")
+            assert isinstance(switch, Switch)
+            switch.value = bool(new_value)
+        except NoMatches:
+            pass
+
+    def on_switch_changed(self, event: Switch.Changed) -> None:
+        """On switch changed."""
+        self.value = event.value
+
+    def get_data(self) -> Any:
+        """The boolean value."""
+        return bool(self.value)
+
+
+class TextAreaControl(FormControl):
+    """A JSON text area for object/array fields."""
+
+    def __init__(self, id: str, value: Any = "", **kwargs) -> None:
+        """Construct a text area control."""
+        if isinstance(value, dict | list):
+            value = json.dumps(value)
+        super().__init__(id=id, value=value, **kwargs)
+
+    def compose(self) -> "ComposeResult":
+        """Yield the widgets."""
+        yield from super().compose()
+        yield TextArea("" if self.value in ("", None) else str(self.value), id=f"{self.id}-input")
+
+    def watch_value(self, old_value: Any, new_value: Any) -> None:
+        """Watch value changes."""
+        try:
+            area = self.query_one(f"#{self.id}-input")
+            assert isinstance(area, TextArea)
+            area.text = "" if new_value in ("", None) else str(new_value)
+        except NoMatches:
+            pass
+
+    def on_text_area_changed(self, event: TextArea.Changed) -> None:
+        """On text area changed."""
+        self.value = event.text_area.text
+
+    def get_data(self) -> Any:
+        """Parse the JSON text into an object/array."""
+        try:
+            return json.loads(self.value)
+        except (json.JSONDecodeError, TypeError):
+            return self.value
 
 
 class Form(Generic[M], Container):
@@ -164,7 +289,7 @@ class Form(Generic[M], Container):
         if data is None:
             data = cls._get_data_from_instance(instance)
         controls = (
-            FormControl.from_field(name=name, field=field, value=data.get(name, ""))
+            FormControl.from_field(name=name, field=field, value=data.get(name))
             for n, (name, field) in enumerate(model.model_fields.items())
         )
         return cls(*controls, model=model, instance=instance, data=data, **kwargs)
@@ -173,10 +298,25 @@ class Form(Generic[M], Container):
     def _get_data_from_instance(cls, instance: BaseModel | None) -> dict[str, Any]:
         return {} if instance is None else json.loads(instance.model_dump_json())
 
-    def on_input_changed(self, event: Input.Changed) -> None:
-        """On input changed."""
+    def _validate_on_input(self) -> None:
         if self.validate_on_input:
             self.validate()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """On input changed."""
+        self._validate_on_input()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """On select changed."""
+        self._validate_on_input()
+
+    def on_switch_changed(self, event: Switch.Changed) -> None:
+        """On switch changed."""
+        self._validate_on_input()
+
+    def on_text_area_changed(self, event: TextArea.Changed) -> None:
+        """On text area changed."""
+        self._validate_on_input()
 
     def validate(self) -> bool:
         """Validate form data against model, if any."""
@@ -225,5 +365,9 @@ class Form(Generic[M], Container):
             field.error = error
 
     def _get_form_data(self) -> dict[str, Any]:
-        data = {child.id: child.value for child in self.children if child.id and isinstance(child, FormControl)}
+        data = {
+            child.id: child.get_data()
+            for child in self.children
+            if child.id and isinstance(child, FormControl)
+        }
         return data

--- a/dokli/tui/screens/generic/execute.py
+++ b/dokli/tui/screens/generic/execute.py
@@ -1,0 +1,62 @@
+"""Shared action confirmation and execution helpers."""
+
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+from pydantic import SecretBytes, SecretStr
+
+from dokli.api_client import APIClient
+from dokli.config import ConnectionConfig
+from dokli.tui.engine import DESTRUCTIVE_VERBS, EntityAction
+from dokli.tui.screens.generic.confirm import ConfirmScreen
+
+
+def build_body(action: EntityAction, data: dict) -> dict:
+    """Build a request body from form data, dropping empties and unwrapping secrets."""
+    body = {}
+    for key, raw_value in data.items():
+        if raw_value in ("", None):
+            continue
+        value = (
+            raw_value.get_secret_value()
+            if isinstance(raw_value, SecretStr | SecretBytes)
+            else raw_value
+        )
+        body[key] = value
+    return body
+
+
+def confirm_and_run(
+    screen,
+    connection: ConnectionConfig,
+    action: EntityAction,
+    body: dict,
+    on_success: Callable[[], Any] | None = None,
+) -> None:
+    """Ask for explicit confirmation, then run the action."""
+    summary = ", ".join(f"{key}={value}" for key, value in body.items()) or "(no body)"
+    danger = action.verb in DESTRUCTIVE_VERBS
+    screen.app.push_screen(
+        ConfirmScreen(title=f"Run {action.route}?", message=summary, danger=danger),
+        callback=lambda confirmed: _run(screen, connection, action, body, on_success) if confirmed else None,
+    )
+
+
+def _run(
+    screen,
+    connection: ConnectionConfig,
+    action: EntityAction,
+    body: dict,
+    on_success: Callable[[], Any] | None,
+) -> None:
+    client = APIClient(connection)
+    params: dict = {"body": body} if body else {}
+    try:
+        client.request(action.method, action.route, params)
+    except httpx.HTTPError as err:
+        screen.notify(f"API error: {err}", severity="error", timeout=10)
+        return
+    screen.notify(f"{action.route} OK")
+    if on_success:
+        on_success()

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -2,19 +2,15 @@
 
 from typing import TYPE_CHECKING
 
-import httpx
-from pydantic import SecretBytes, SecretStr
-from textual import log
 from textual.binding import Binding
-from textual.message import Message
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header
 
-from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
-from dokli.tui.engine import DESTRUCTIVE_VERBS, EntityAction, build_form_model
+from dokli.tui.engine import EntityAction, build_form_model
 from dokli.tui.forms import Form
-from dokli.tui.screens.generic.confirm import ConfirmScreen
+from dokli.tui.screens.generic.execute import build_body, confirm_and_run
+from dokli.tui.screens.generic.wizard import WizardScreen
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -25,17 +21,9 @@ class ActionFormScreen(Screen):
 
     BINDINGS = [
         Binding("ctrl+s", "submit", "Submit"),
+        Binding("w", "wizard", "Wizard mode"),
         Binding("escape", "cancel", "Cancel"),
     ]
-
-    class Submitted(Message):
-        """The form was submitted successfully."""
-
-        def __init__(self, route: str, response: httpx.Response) -> None:
-            """Construct the message."""
-            super().__init__()
-            self.route = route
-            self.response = response
 
     def __init__(
         self,
@@ -60,6 +48,7 @@ class ActionFormScreen(Screen):
         yield Footer()
         yield self.form
         yield Button("Submit", id="submit", variant="primary")
+        yield Button("Wizard mode", id="wizard")
         yield Button("Cancel", id="cancel")
 
     def on_screen_resume(self, event) -> None:
@@ -70,6 +59,8 @@ class ActionFormScreen(Screen):
         """Handle buttons."""
         if event.button.id == "submit":
             self.action_submit()
+        elif event.button.id == "wizard":
+            self.action_wizard()
         elif event.button.id == "cancel":
             self.action_cancel()
 
@@ -84,42 +75,20 @@ class ActionFormScreen(Screen):
         if missing:
             self.notify(f"Missing required: {', '.join(missing)}", severity="error", timeout=10)
             return
-        body = {}
-        for key, raw_value in data.items():
-            if raw_value in ("", None):
-                continue
-            value = (
-                raw_value.get_secret_value()
-                if isinstance(raw_value, SecretStr | SecretBytes)
-                else raw_value
-            )
-            body[key] = value
-        self._confirm_execute(body)
-
-    def _confirm_execute(self, body: dict) -> None:
-        summary = ", ".join(f"{key}={value}" for key, value in body.items())
-        danger = self.action.verb in DESTRUCTIVE_VERBS
-        self.app.push_screen(
-            ConfirmScreen(
-                title=f"Run {self.action.route}?",
-                message=summary,
-                danger=danger,
-            ),
-            callback=lambda confirmed: self._execute(body) if confirmed else None,
+        body = build_body(self.action, data)
+        confirm_and_run(
+            self,
+            self.connection,
+            self.action,
+            body,
+            on_success=lambda: self.dismiss(None),
         )
 
-    def _execute(self, body: dict) -> None:
-        log("submitting", self.action.route, body)
-        client = APIClient(self.connection)
-        try:
-            response = client.request(self.action.method, self.action.route, {"body": body})
-        except httpx.HTTPError as err:
-            self.notify(f"API error: {err}", severity="error", timeout=10)
-            log("api error", err)
-            return
-        self.post_message(self.Submitted(self.action.route, response))
-        self.notify(f"{self.action.route} OK")
-        self.dismiss(None)
+    def action_wizard(self) -> None:
+        """Open the step-by-step wizard for the same action."""
+        self.app.push_screen(
+            WizardScreen(self.connection, self.action, record=self.record, classes="Entities")
+        )
 
     def action_cancel(self) -> None:
         """Cancel the form."""

--- a/dokli/tui/screens/generic/record.py
+++ b/dokli/tui/screens/generic/record.py
@@ -19,7 +19,7 @@ from dokli.tui.engine import (
     record_id,
     record_title,
 )
-from dokli.tui.screens.generic.confirm import ConfirmScreen
+from dokli.tui.screens.generic.execute import confirm_and_run
 from dokli.tui.screens.generic.form import ActionFormScreen
 
 if TYPE_CHECKING:
@@ -231,26 +231,11 @@ class RecordScreen(Screen):
                 for key, value in self.record.items()
                 if key in schema["properties"] and value is not None
             }
-        danger = action.verb in DESTRUCTIVE_VERBS
-        title = f"Run {action.route}?"
-        message = ", ".join(f"{key}={value}" for key, value in body.items()) or "(no body)"
-        self.app.push_screen(
-            ConfirmScreen(title=title, message=message, danger=danger),
-            callback=lambda confirmed: self._run_action(action, body) if confirmed else None,
-        )
-
-    def _run_action(self, action, body: dict) -> None:
-        client = APIClient(self.connection)
-        params: dict = {}
-        if body:
-            params["body"] = body
-        try:
-            client.request(action.method, action.route, params)
-        except httpx.HTTPError as err:
-            self.notify(f"API error: {err}", severity="error", timeout=10)
-            return
-        self.notify(f"{action.route} OK")
         if action.verb in DESTRUCTIVE_VERBS:
-            self.dismiss(None)
+
+            def on_success() -> None:
+                self.dismiss(None)
+
         else:
-            self.action_refresh()
+            on_success = self.action_refresh
+        confirm_and_run(self, self.connection, action, body, on_success=on_success)

--- a/dokli/tui/screens/generic/wizard.py
+++ b/dokli/tui/screens/generic/wizard.py
@@ -1,0 +1,116 @@
+"""Step-by-step wizard form (one field at a time)."""
+
+from typing import TYPE_CHECKING
+
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Header, Label
+
+from dokli.config import ConnectionConfig
+from dokli.tui.engine import EntityAction, build_form_model
+from dokli.tui.forms import FormControl
+from dokli.tui.screens.generic.execute import build_body, confirm_and_run
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class WizardScreen(Screen):
+    """Prompt each field of an action form in sequence."""
+
+    BINDINGS = [
+        Binding("ctrl+n", "next", "Next"),
+        Binding("ctrl+p", "back", "Back"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        connection: ConnectionConfig,
+        action: EntityAction,
+        record: dict | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Construct the wizard screen."""
+        super().__init__(*args, **kwargs)
+        self.connection = connection
+        self.action = action
+        self.record = record or {}
+        self.model = build_form_model(action.request_schema, name=f"{action.route}Wizard")
+        self.fields = list(self.model.model_fields.items())
+        self.controls = {
+            name: FormControl.from_field(name, field, value=self.record.get(name))
+            for name, field in self.fields
+        }
+        self.index = 0
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield Label("", id="prompt", classes="title")
+        yield Container(id="control")
+        yield Button("Back", id="back")
+        yield Button("Next", id="next", variant="primary")
+        yield Button("Cancel", id="cancel")
+
+    def on_screen_resume(self, event) -> None:
+        """On screen resume."""
+        self.app.sub_title = f"{self.connection.name} - {self.action.route} (wizard)"
+        self._show()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle buttons."""
+        if event.button.id == "back":
+            self.action_back()
+        elif event.button.id == "next":
+            self.action_next()
+        elif event.button.id == "cancel":
+            self.action_cancel()
+
+    def _show(self) -> None:
+        name, field = self.fields[self.index]
+        control = self.controls[name]
+        container = self.query_one("#control", Container)
+        container.remove_children()
+        container.mount(control)
+        self.query_one("#prompt", Label).update(
+            f"({self.index + 1}/{len(self.fields)}) {field.title or name}"
+        )
+        control.focus()
+
+    def action_next(self) -> None:
+        """Advance to the next field, or finish on the last one."""
+        if self.index < len(self.fields) - 1:
+            self.index += 1
+            self._show()
+        else:
+            self._finish()
+
+    def action_back(self) -> None:
+        """Go back to the previous field."""
+        if self.index > 0:
+            self.index -= 1
+            self._show()
+
+    def action_cancel(self) -> None:
+        """Cancel the wizard."""
+        self.dismiss(None)
+
+    def _finish(self) -> None:
+        data = {name: self.controls[name].get_data() for name, _ in self.fields}
+        required = [name for name in self.action.request_schema.get("required", []) if name in self.controls]
+        missing = [name for name in required if not data.get(name)]
+        if missing:
+            self.notify(f"Missing required: {', '.join(missing)}", severity="error", timeout=10)
+            return
+        body = build_body(self.action, data)
+        confirm_and_run(
+            self,
+            self.connection,
+            self.action,
+            body,
+            on_success=lambda: self.dismiss(None),
+        )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -5,11 +5,12 @@ import asyncio
 from dokli.config import Config, ConnectionConfig
 from dokli.tui.app import DokliApp
 from dokli.tui.engine import build_form_model, parse_spec
-from dokli.tui.forms import Form
+from dokli.tui.forms import Form, SelectControl, SwitchControl, TextAreaControl
 from dokli.tui.screens.generic.confirm import ConfirmScreen
 from dokli.tui.screens.generic.form import ActionFormScreen
 from dokli.tui.screens.generic.home import EntityItem, HomeScreen
 from dokli.tui.screens.generic.record import ActionItem, RecordScreen
+from dokli.tui.screens.generic.wizard import WizardScreen
 
 FAKE_SCHEMA = {
     "paths": {
@@ -24,7 +25,10 @@ FAKE_SCHEMA = {
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "properties": {"name": {"type": "string"}},
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "description": {"type": "string"},
+                                },
                                 "required": ["name"],
                             }
                         }
@@ -48,11 +52,57 @@ def test_form_prefills_from_data():
     assert form.fields["name"].value == "prefilled"
 
 
+def test_form_rich_controls():
+    """We expect enums, booleans and objects to map to rich controls."""
+    model = build_form_model(
+        {
+            "properties": {
+                "mode": {"type": "string", "enum": ["dev", "prod"]},
+                "enabled": {"type": "boolean"},
+                "labels": {"type": "object"},
+                "name": {"type": "string"},
+            }
+        }
+    )
+    form = Form.from_model(model, data={"enabled": True, "labels": {"a": 1}})
+    assert isinstance(form.fields["mode"], SelectControl)
+    assert isinstance(form.fields["enabled"], SwitchControl)
+    assert isinstance(form.fields["labels"], TextAreaControl)
+    assert form.fields["enabled"].get_data() is True
+
+
+def test_wizard_steps_through_fields(mocker):
+    """We expect the wizard to step through fields one at a time."""
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    config = Config(connections=[connection])
+    mocker.patch("dokli.tui.app.APIClient")
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("project").get("create")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            screen = WizardScreen(connection, action)
+            app.install_screen(screen, name="wizard")
+            app.push_screen("wizard")
+            await pilot.pause()
+            prompt = app.screen.query_one("#prompt")
+            assert "1/2" in str(prompt.renderable)
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert "2/2" in str(app.screen.query_one("#prompt").renderable)
+
+    _run(main())
+
+
 def test_form_control_coerces_non_string_values():
-    """We expect boolean/number prefill values not to crash the input."""
+    """We expect boolean fields to map to a switch and not crash the input."""
     model = build_form_model({"properties": {"autoDeploy": {"type": "boolean"}}})
     form = Form.from_model(model, data={"autoDeploy": True})
-    assert form.fields["autoDeploy"].value == "True"
+    from dokli.tui.forms import SwitchControl
+
+    assert isinstance(form.fields["autoDeploy"], SwitchControl)
+    assert form.fields["autoDeploy"].get_data() is True
 
 
 def test_form_submit_asks_confirmation(mocker):
@@ -60,7 +110,7 @@ def test_form_submit_asks_confirmation(mocker):
     connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
     config = Config(connections=[connection])
     mocker.patch("dokli.tui.app.APIClient")
-    mocker.patch("dokli.tui.screens.generic.form.APIClient")
+    mocker.patch("dokli.tui.screens.generic.execute.APIClient")
     registry = parse_spec(FAKE_SCHEMA)
     action = registry.get("project").get("create")
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -71,6 +71,21 @@ def test_form_rich_controls():
     assert form.fields["enabled"].get_data() is True
 
 
+def test_multiline_string_fields():
+    """We expect known multiline and newline-valued strings to be text areas."""
+    model = build_form_model(
+        {"properties": {"description": {"type": "string"}, "name": {"type": "string"}}}
+    )
+    form = Form.from_model(model, data={"description": "line1\nline2"})
+    assert isinstance(form.fields["description"], TextAreaControl)
+    assert form.fields["description"].get_data() == "line1\nline2"
+    assert not isinstance(form.fields["name"], TextAreaControl)
+
+    model2 = build_form_model({"properties": {"foo": {"type": "string"}}})
+    form2 = Form.from_model(model2, data={"foo": "a\nb"})
+    assert isinstance(form2.fields["foo"], TextAreaControl)
+
+
 def test_wizard_steps_through_fields(mocker):
     """We expect the wizard to step through fields one at a time."""
     connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -181,6 +181,13 @@ class TestBuildFormModel:
         )
         assert model(mode="dev").mode == "dev"
 
+    def test_anyof_annotation(self):
+        """We expect anyOf null-unions to be unwrapped."""
+        model = build_form_model(
+            {"properties": {"autoDeploy": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}}}
+        )
+        assert model(autoDeploy=True).autoDeploy is True
+
     def test_filters_read_only_fields(self):
         """We expect server-managed fields to be filtered from the form."""
         model = build_form_model(


### PR DESCRIPTION
Part of #42 — Phase R1 of the generative TUI.

## What's in this PR

- **Rich form controls** (`dokli/tui/forms.py`): fields are now mapped from their JSON schema type —
  - string enums → `Select` dropdown
  - booleans → `Switch` toggle
  - object/array → `TextArea` (JSON, parsed on submit)
  - secrets → password `Input`; numbers/text → `Input`
  - `anyOf`/PEP-604 unions are unwrapped (e.g. `autoDeploy: anyOf[boolean, null]` → `Switch`)
- **Wizard mode** (`wizard.py`): step-by-step prompt of each field (`Ctrl+N` next, `Ctrl+P` back), finishing with the shared confirm + execute flow.
- **Shared execution helper** (`execute.py`): `build_body` (drops empties, unwraps secrets) + `confirm_and_run` (explicit confirmation → run) — now used by the form, record actions and wizard (removes duplication).

## Verified

- `make dev-tui` imports (fixed the `Unable to import 'DokliApp'` from the mid-refactor import).
- Against `dokploy.meche.lan`, `compose.update` renders 35 inputs, **2 Selects** (`sourceType`, `composeType`), **5 Switches** (incl. `autoDeploy` from `anyOf`).
- Wizard mounts with all 41 fields and `Ctrl+N` advances.
- `make lint` ✓, `make test` → 92 passed ✓

Next: R2 (results screen + error polish) or R3 (connections persistence + Help + command palette).
