### PR TITLE
Generative TUI (R3): connections persistence, Help, command palette

### DIFF
--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -117,9 +117,7 @@ class Applier:
             self._plan_services(project_def, project_def.services)
             for env_def in project_def.environments:
                 self.report.actions.append(
-                    ApplyAction(
-                        action="create", kind="environment", project=project_def.name, name=env_def.name
-                    )
+                    ApplyAction(action="create", kind="environment", project=project_def.name, name=env_def.name)
                 )
                 self._plan_services(project_def, env_def.services)
             return

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -3,8 +3,10 @@
 import json
 import os
 import subprocess
+from pathlib import Path
 from typing import Any
 
+import yaml
 from pydantic import BaseModel, Field, HttpUrl, SecretStr, field_serializer, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, YamlConfigSettingsSource
 
@@ -32,7 +34,7 @@ class ConnectionConfig(BaseModel):
     @field_serializer("api_key", when_used="json")
     def dump_secret(self, v):
         """Allows dumping secret values."""
-        return v.get_secret_value()
+        return v.get_secret_value() if v is not None else None
 
     def model_dump_clear(self, **kwargs) -> dict[str, Any]:
         """Allows dumping the config with clear secrets."""
@@ -88,3 +90,20 @@ class Config(BaseSettings):
     def get_connection(self, name: str) -> ConnectionConfig:
         """Get connection config."""
         return next(filter(lambda x: x.name == name, self.connections))
+
+    def save(self, path: str | Path | None = None) -> None:
+        """Persist connections to the YAML config file.
+
+        Args:
+            path: Where to write. Defaults to the ``DOKLI_CONFIG`` env var or
+                ``~/.config/dokli/dokli.yaml``.
+        """
+        target = (
+            Path(os.getenv("DOKLI_CONFIG", "~/.config/dokli/dokli.yaml")) if path is None else Path(path)
+        ).expanduser()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        connections = [
+            {key: value for key, value in connection.model_dump(mode="json").items() if value is not None}
+            for connection in self.connections
+        ]
+        target.write_text(yaml.safe_dump({"connections": connections}, sort_keys=False))

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -91,16 +91,31 @@ class Config(BaseSettings):
         """Get connection config."""
         return next(filter(lambda x: x.name == name, self.connections))
 
+    def _config_path(self) -> Path:
+        """The config file to save to, mirroring the load order.
+
+        ``dokli.yaml`` in the cwd wins over ``DOKLI_CONFIG``/the default, just
+        like ``yaml_file`` loading.
+        """
+        candidates = [
+            "dokli.yaml",
+            os.getenv("DOKLI_CONFIG", "~/.config/dokli/dokli.yaml"),
+        ]
+        for candidate in candidates:
+            path = Path(candidate).expanduser()
+            if path.exists():
+                return path
+        return Path(candidates[-1]).expanduser()
+
     def save(self, path: str | Path | None = None) -> None:
         """Persist connections to the YAML config file.
 
         Args:
-            path: Where to write. Defaults to the ``DOKLI_CONFIG`` env var or
-                ``~/.config/dokli/dokli.yaml``.
+            path: Where to write. Defaults to the config file that would be
+                loaded (``dokli.yaml`` if present, else ``DOKLI_CONFIG`` or
+                ``~/.config/dokli/dokli.yaml``).
         """
-        target = (
-            Path(os.getenv("DOKLI_CONFIG", "~/.config/dokli/dokli.yaml")) if path is None else Path(path)
-        ).expanduser()
+        target = Path(path).expanduser() if path is not None else self._config_path()
         target.parent.mkdir(parents=True, exist_ok=True)
         connections = [
             {key: value for key, value in connection.model_dump(mode="json").items() if value is not None}

--- a/dokli/export.py
+++ b/dokli/export.py
@@ -46,9 +46,7 @@ def _export_git_providers(state: State, warnings: list[str]) -> list[GitProvider
     providers = []
     for provider in state.git_providers:
         if provider.provider not in SUPPORTED_PROVIDERS:
-            warnings.append(
-                f"Git provider '{provider.name}': unsupported type '{provider.provider}', skipping."
-            )
+            warnings.append(f"Git provider '{provider.name}': unsupported type '{provider.provider}', skipping.")
             continue
         kwargs: dict = {
             "name": provider.name,
@@ -113,8 +111,7 @@ def _redact_env(live: LiveService, include_secrets: bool, warnings: list[str]) -
     if include_secrets:
         return live.env
     warnings.append(
-        f"Environment variables of '{live.name}' were redacted. "
-        "Re-run with --include-secrets to export them."
+        f"Environment variables of '{live.name}' were redacted. " "Re-run with --include-secrets to export them."
     )
     return None
 

--- a/dokli/formatting.py
+++ b/dokli/formatting.py
@@ -12,9 +12,7 @@ from rich.table import Table
 
 app = typer.Typer()
 
-SECRET_KEY_PATTERN = re.compile(
-    r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|access[_-]?key)"
-)
+SECRET_KEY_PATTERN = re.compile(r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|access[_-]?key)")
 
 D = TypeVar("D")
 

--- a/dokli/openapi_cli.py
+++ b/dokli/openapi_cli.py
@@ -53,10 +53,7 @@ def _api_command_factory(connection, route, method="GET", params=None, request_b
     # Create a list of parameters for the signature
     original_name = {_safe_param_name(x["name"]): x["name"] for x in params}
     param_hints = {_safe_param_name(p["name"]): _infer_param_type(p) for p in params}
-    parameters = [
-        Parameter(name, Parameter.KEYWORD_ONLY, annotation=typ)
-        for name, typ in param_hints.items()
-    ]
+    parameters = [Parameter(name, Parameter.KEYWORD_ONLY, annotation=typ) for name, typ in param_hints.items()]
     if request_body and request_body.get("required", False):
         parameters.append(
             Parameter("body", Parameter.KEYWORD_ONLY, annotation=Annotated[str, typer.Option(help="JSON body")])

--- a/dokli/state.py
+++ b/dokli/state.py
@@ -106,9 +106,7 @@ def collect_state(connection: ConnectionConfig, client: APIClient | None = None)
 
     provider_map = _build_provider_map(raw_providers)
 
-    projects = [
-        _collect_project(client, raw_project, provider_map) for raw_project in raw_projects
-    ]
+    projects = [_collect_project(client, raw_project, provider_map) for raw_project in raw_projects]
 
     return State(
         connection=connection.name,
@@ -192,9 +190,8 @@ def _collect_git_provider(raw: dict[str, Any]) -> LiveGitProvider:
         provider=raw.get("providerType") or "",
         url=subprovider.get("url") if isinstance(subprovider, dict) else None,
         app_name=subprovider.get("appName") if isinstance(subprovider, dict) else None,
-        is_configured=bool(raw.get("isConfigured")) or (
-            isinstance(subprovider, dict) and bool(subprovider.get("isConfigured"))
-        ),
+        is_configured=bool(raw.get("isConfigured"))
+        or (isinstance(subprovider, dict) and bool(subprovider.get("isConfigured"))),
         github_id=(raw.get("github") or {}).get("githubId"),
         gitlab_id=(raw.get("gitlab") or {}).get("gitlabId"),
         gitea_id=(raw.get("gitea") or {}).get("giteaId"),

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -68,6 +68,7 @@ class DokliApp(App):
         ("d", "toggle_dark", "Toggle dark mode"),
         ("C", "connections", "Connections"),
         ("?", "help", "Help"),
+        ("ctrl+p", "command_palette", "Command palette"),
         ("escape", "cancel", "Cancel/Back"),
         ("q", "quit", "Quit"),
     ]

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -218,11 +218,17 @@ class DokliApp(App):
             self._connection_failed(connection, err)
             return
         registry = parse_spec(schema)
-        self.install_screen(
-            BrowserScreen(name="Browser", connection=self.connection, registry=registry),
-            name="Browser",
-        )
-        self.push_screen("Browser")
+        browser = self._installed_screens.get("Browser")
+        if isinstance(browser, BrowserScreen):
+            browser.reload(connection, registry)
+        else:
+            browser = BrowserScreen(name="Browser", connection=connection, registry=registry)
+            self.install_screen(browser, name="Browser")
+        if browser in self.screen_stack:
+            while self.screen_stack and self.screen_stack[-1] is not browser:
+                self.pop_screen()
+        else:
+            self.push_screen("Browser")
 
     def _connection_failed(self, connection: ConnectionConfig, err: Exception) -> None:
         """Fall back to the connections screen when a connection is unreachable."""

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -1,10 +1,14 @@
 """Dokli TUI."""
 
+from collections.abc import Callable
+from functools import partial
 from pathlib import Path
+from typing import Any, cast
 
 import httpx
 from textual import events, log
-from textual.app import App, ComposeResult
+from textual.app import App, ComposeResult, get_system_commands
+from textual.command import DiscoveryHit, Hit, Hits, Provider
 from textual.widgets import Footer, Header, Static
 
 from dokli.api_client import APIClient
@@ -12,10 +16,46 @@ from dokli.config import Config, ConnectionConfig
 from dokli.tui.engine import parse_spec
 from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.generic.browser import BrowserScreen
+from dokli.tui.screens.generic.help import HelpScreen
 from dokli.tui.screens.settings import SettingsScreen
 
 TUI_PATH = Path(__file__).parent
 ASCII_ART_PATH = TUI_PATH / "asciiart"
+
+
+class DokliCommands(Provider):
+    """Commands for the Dokli command palette."""
+
+    def _commands(self) -> list[tuple[str, str, Callable[[], Any]]]:
+        app = cast(DokliApp, self.app)
+        commands = [
+            ("Toggle dark mode", "Switch between light and dark themes", app.action_toggle_dark),
+            ("Connections", "Open the connections screen", app.action_connections),
+            ("Settings", "Open the settings screen", app.action_settings),
+            ("Help", "Show the keybindings", app.action_help),
+            ("Quit", "Exit the app", app.action_quit),
+        ]
+        for connection in app.config.connections:
+            commands.append(
+                (
+                    f"Open {connection.name}",
+                    f"Open the browser on the {connection.name} connection",
+                    partial(app.set_connection, connection),
+                )
+            )
+        return commands
+
+    async def search(self, query: str) -> Hits:
+        """Search commands by name."""
+        query = query.lower()
+        for name, help_text, callback in self._commands():
+            if query in name.lower():
+                yield Hit(1.0, name, callback, name, help_text)
+
+    async def discover(self) -> Hits:
+        """Show all commands when the palette is opened empty."""
+        for name, help_text, callback in self._commands():
+            yield DiscoveryHit(name, callback, name, help_text)
 
 
 class DokliApp(App):
@@ -23,9 +63,11 @@ class DokliApp(App):
 
     TITLE = "Dokli"
     CSS_PATH = "css/tui.css"
+    COMMANDS = {get_system_commands, DokliCommands}
     BINDINGS = [
         ("d", "toggle_dark", "Toggle dark mode"),
         ("C", "connections", "Connections"),
+        ("?", "help", "Help"),
         ("escape", "cancel", "Cancel/Back"),
         ("q", "quit", "Quit"),
     ]
@@ -65,6 +107,14 @@ class DokliApp(App):
         else:
             self.bell()
 
+    def action_help(self) -> None:
+        """Open the help screen."""
+        self.push_screen(HelpScreen(classes="Help"))
+
+    def action_settings(self) -> None:
+        """Open the settings screen."""
+        self.push_screen("Settings")
+
     def set_connection(self, connection: ConnectionConfig) -> None:
         """Set the active connection and open the entity browser."""
         self.connection = connection
@@ -90,9 +140,38 @@ class DokliApp(App):
         """Handle connection set screen event."""
         self.set_connection(event.connection)
 
+    def on_connections_screen_add_connection(self, event: ConnectionsScreen.AddConnection) -> None:
+        """Persist a newly added connection."""
+        self._save_connection(event.connection)
+        self.notify(f"Added connection '{event.connection.name}'.")
+
+    def on_connections_screen_update_connection(self, event: ConnectionsScreen.UpdateConnection) -> None:
+        """Persist an edited connection."""
+        self._save_connection(event.connection)
+        self.notify(f"Updated connection '{event.connection.name}'.")
+
+    def on_connections_screen_delete_connection(self, event: ConnectionsScreen.DeleteConnection) -> None:
+        """Persist a deleted connection."""
+        self.config.connections = [
+            connection for connection in self.config.connections if connection.name != event.connection.name
+        ]
+        self.config.save()
+        self.notify(f"Deleted connection '{event.connection.name}'.")
+
+    def _save_connection(self, connection: ConnectionConfig) -> None:
+        """Add or update a connection in the config and persist it."""
+        names = [existing.name for existing in self.config.connections]
+        if connection.name in names:
+            self.config.connections = [
+                connection if existing.name == connection.name else existing for existing in self.config.connections
+            ]
+        else:
+            self.config.connections = [*self.config.connections, connection]
+        self.config.save()
+
     def action_connections(self) -> None:
         """Action connections."""
-        if self.connection:
+        if self.screen.name != "Connections":
             self.push_screen("Connections")
 
     def compose(self) -> "ComposeResult":

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -9,6 +9,7 @@ import httpx
 from textual import events, log
 from textual.app import App, ComposeResult, get_system_commands
 from textual.command import DiscoveryHit, Hit, Hits, Provider
+from textual.design import ColorSystem
 from textual.widgets import Footer, Header, Static
 
 from dokli.api_client import APIClient
@@ -22,6 +23,34 @@ from dokli.tui.screens.settings import SettingsScreen
 
 TUI_PATH = Path(__file__).parent
 ASCII_ART_PATH = TUI_PATH / "asciiart"
+
+
+def _catppuccin_design() -> dict[str, ColorSystem]:
+    """A Catppuccin (Mocha/Latte) color system for the app."""
+    return {
+        "dark": ColorSystem(
+            primary="#cba6f7",
+            secondary="#f5c2e7",
+            warning="#f9e2af",
+            error="#f38ba8",
+            success="#a6e3a1",
+            accent="#89b4fa",
+            background="#1e1e2e",
+            surface="#313244",
+            dark=True,
+        ),
+        "light": ColorSystem(
+            primary="#8839ef",
+            secondary="#ea76cb",
+            warning="#df8e1d",
+            error="#d20f39",
+            success="#40a02b",
+            accent="#1e66f5",
+            background="#eff1f5",
+            surface="#ccd0da",
+            dark=False,
+        ),
+    }
 
 
 class DokliCommands(Provider):
@@ -147,6 +176,7 @@ class DokliApp(App):
     ) -> None:
         """Construct a new TUI app."""
         super().__init__(**kwargs)
+        self.design = _catppuccin_design()
         self.config = config or Config()
         self.connection: ConnectionConfig | None = connection
 

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -236,11 +236,13 @@ class DokliApp(App):
     def on_connections_screen_add_connection(self, event: ConnectionsScreen.AddConnection) -> None:
         """Persist a newly added connection."""
         self._save_connection(event.connection)
+        self._sync_connections_list()
         self.notify(f"Added connection '{event.connection.name}'.")
 
     def on_connections_screen_update_connection(self, event: ConnectionsScreen.UpdateConnection) -> None:
         """Persist an edited connection."""
-        self._save_connection(event.connection)
+        self._save_connection(event.connection, original=event.original)
+        self._sync_connections_list()
         self.notify(f"Updated connection '{event.connection.name}'.")
 
     def on_connections_screen_delete_connection(self, event: ConnectionsScreen.DeleteConnection) -> None:
@@ -249,18 +251,33 @@ class DokliApp(App):
             connection for connection in self.config.connections if connection.name != event.connection.name
         ]
         self.config.save()
+        self._sync_connections_list()
         self.notify(f"Deleted connection '{event.connection.name}'.")
 
-    def _save_connection(self, connection: ConnectionConfig) -> None:
-        """Add or update a connection in the config and persist it."""
+    def _save_connection(self, connection: ConnectionConfig, original: ConnectionConfig | None = None) -> None:
+        """Add or update a connection in the config and persist it.
+
+        When ``original`` is given (edit with a possible rename), the entry is
+        replaced by the original's identity so a rename does not duplicate it.
+        """
         names = [existing.name for existing in self.config.connections]
-        if connection.name in names:
-            self.config.connections = [
-                connection if existing.name == connection.name else existing for existing in self.config.connections
-            ]
+        if original is not None and original.name in names:
+            target = original.name
+        elif connection.name in names:
+            target = connection.name
         else:
             self.config.connections = [*self.config.connections, connection]
+            self.config.save()
+            return
+        self.config.connections = [
+            connection if existing.name == target else existing for existing in self.config.connections
+        ]
         self.config.save()
+
+    def _sync_connections_list(self) -> None:
+        """Refresh the connections screen list from the persisted config."""
+        if self.screen_stack and isinstance(self.screen_stack[-1], ConnectionsScreen):
+            self.screen_stack[-1].connections = list(self.config.connections)
 
     def action_connections(self) -> None:
         """Action connections."""

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -58,7 +58,7 @@ class DokliCommands(Provider):
 
     # Core commands that have an app-level keybinding shown in the help line.
     _CORE_KEYS = {
-        "Toggle dark mode": "d",
+        "Toggle dark mode": "D",
         "Connections": "C",
         "Help": "?",
         "Quit": "q",
@@ -156,7 +156,7 @@ class DokliApp(App):
     CSS_PATH = "css/tui.css"
     COMMANDS = {get_system_commands, DokliCommands}
     BINDINGS = [
-        ("d", "toggle_dark", "Toggle dark mode"),
+        ("D", "toggle_dark", "Toggle dark mode"),
         ("C", "connections", "Connections"),
         ("?", "help", "Help"),
         ("ctrl+p", "command_palette", "Command palette"),

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -27,6 +27,14 @@ ASCII_ART_PATH = TUI_PATH / "asciiart"
 class DokliCommands(Provider):
     """Commands for the Dokli command palette (context-aware)."""
 
+    # Core commands that have an app-level keybinding shown in the help line.
+    _CORE_KEYS = {
+        "Toggle dark mode": "d",
+        "Connections": "C",
+        "Help": "?",
+        "Quit": "q",
+    }
+
     def _commands(self) -> list[tuple[str, str, Callable[[], Any]]]:
         app = cast(DokliApp, self.app)
         commands = [
@@ -35,6 +43,10 @@ class DokliCommands(Provider):
             ("Settings", "Open the settings screen", app.action_settings),
             ("Help", "Show the keybindings", app.action_help),
             ("Quit", "Exit the app", app.action_quit),
+        ]
+        commands = [
+            (name, _with_key(help_text, self._CORE_KEYS.get(name)), callback)
+            for name, help_text, callback in commands
         ]
         commands.extend(_screen_commands(self.screen))
         for connection in app.config.connections:
@@ -83,6 +95,11 @@ def _screen_commands(screen) -> list[tuple[str, str, Callable[[], Any]]]:
     return commands
 
 
+def _with_key(help_text: str, key: str | None) -> str:
+    """Prepend a shortcut to a command's help line when it has one."""
+    return f"[{key}] {help_text}" if key else help_text
+
+
 def _browser_commands(screen: BrowserScreen) -> list[tuple[str, str, Callable[[], Any]]]:
     """Commands for the browser: the selected entity's available actions."""
     commands: list[tuple[str, str, Callable[[], Any]]] = []
@@ -92,11 +109,12 @@ def _browser_commands(screen: BrowserScreen) -> list[tuple[str, str, Callable[[]
         return commands
     selected = screen.selected or {}
     title = record_title(selected) if selected else (kind or "record")
-    for action, _key in screen._entity_bindings(entity):
+    for action, key in screen._entity_bindings(entity):
+        help_text = _with_key(f"{action.verb} · {kind} ({action.method})", key)
         commands.append(
             (
                 f"Run {action.verb} on {title}",
-                f"{action.verb} · {kind} ({action.method})",
+                help_text,
                 partial(screen._run_action, action),
             )
         )

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -74,8 +74,7 @@ class DokliCommands(Provider):
             ("Quit", "Exit the app", app.action_quit),
         ]
         commands = [
-            (name, _with_key(help_text, self._CORE_KEYS.get(name)), callback)
-            for name, help_text, callback in commands
+            (name, _with_key(help_text, self._CORE_KEYS.get(name)), callback) for name, help_text, callback in commands
         ]
         commands.extend(_screen_commands(self.screen))
         for connection in app.config.connections:

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -13,9 +13,10 @@ from textual.widgets import Footer, Header, Static
 
 from dokli.api_client import APIClient
 from dokli.config import Config, ConnectionConfig
-from dokli.tui.engine import parse_spec
+from dokli.tui.engine import parse_spec, record_title
 from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.generic.browser import BrowserScreen
+from dokli.tui.screens.generic.form import ActionFormScreen
 from dokli.tui.screens.generic.help import HelpScreen
 from dokli.tui.screens.settings import SettingsScreen
 
@@ -24,7 +25,7 @@ ASCII_ART_PATH = TUI_PATH / "asciiart"
 
 
 class DokliCommands(Provider):
-    """Commands for the Dokli command palette."""
+    """Commands for the Dokli command palette (context-aware)."""
 
     def _commands(self) -> list[tuple[str, str, Callable[[], Any]]]:
         app = cast(DokliApp, self.app)
@@ -35,6 +36,7 @@ class DokliCommands(Provider):
             ("Help", "Show the keybindings", app.action_help),
             ("Quit", "Exit the app", app.action_quit),
         ]
+        commands.extend(_screen_commands(self.screen))
         for connection in app.config.connections:
             commands.append(
                 (
@@ -56,6 +58,49 @@ class DokliCommands(Provider):
         """Show all commands when the palette is opened empty."""
         for name, help_text, callback in self._commands():
             yield DiscoveryHit(name, callback, name, help_text)
+
+
+def _screen_commands(screen) -> list[tuple[str, str, Callable[[], Any]]]:
+    """Context-aware commands for the screen that opened the palette."""
+    commands: list[tuple[str, str, Callable[[], Any]]] = []
+    if isinstance(screen, BrowserScreen):
+        commands.extend(_browser_commands(screen))
+    elif isinstance(screen, ActionFormScreen):
+        commands.extend(
+            [
+                ("Submit form", "Validate and run the form action", screen.action_submit),
+                ("Wizard mode", "Step through the fields one at a time", screen.action_wizard),
+                ("Cancel", "Close the form without running", screen.action_cancel),
+            ]
+        )
+    elif isinstance(screen, ConnectionsScreen):
+        commands.extend(
+            [
+                ("Add connection", "Create a new connection", screen.action_add_connection),
+                ("Edit connection", "Edit the highlighted connection", screen.action_edit_connection),
+            ]
+        )
+    return commands
+
+
+def _browser_commands(screen: BrowserScreen) -> list[tuple[str, str, Callable[[], Any]]]:
+    """Commands for the browser: the selected entity's available actions."""
+    commands: list[tuple[str, str, Callable[[], Any]]] = []
+    kind = screen._selected_kind()
+    entity = screen.registry.get(kind or "")
+    if entity is None:
+        return commands
+    selected = screen.selected or {}
+    title = record_title(selected) if selected else (kind or "record")
+    for action, _key in screen._entity_bindings(entity):
+        commands.append(
+            (
+                f"Run {action.verb} on {title}",
+                f"{action.verb} · {kind} ({action.method})",
+                partial(screen._run_action, action),
+            )
+        )
+    return commands
 
 
 class DokliApp(App):

--- a/dokli/tui/css/tui.css
+++ b/dokli/tui/css/tui.css
@@ -106,6 +106,17 @@ ConnectionWidget Label#icon {
   background: $success;
 }
 
+Horizontal.actions {
+  margin-top: 1;
+  height: 5;
+}
+
+Horizontal.actions Button {
+  width: 1fr;
+  margin-left: 1;
+  margin-right: 1;
+}
+
 ConnectionScreen Horizontal {
   margin-top: 1;
   min-width: 50;

--- a/dokli/tui/css/tui.css
+++ b/dokli/tui/css/tui.css
@@ -1,5 +1,5 @@
-$error-color: #b93c5b;
-$success-color: #61ff61;
+$error-color: #f38ba8;
+$success-color: #a6e3a1;
 .hidden {
   display: none;
 }

--- a/dokli/tui/css/tui.css
+++ b/dokli/tui/css/tui.css
@@ -93,6 +93,17 @@ FormControl.error Input {
 FormControl.error Label.error-msg {
   text-style: bold;
   color: $error-color;
+  display: block;
+}
+
+Label.form-error {
+  color: $error-color;
+  margin: 0 2;
+  display: none;
+}
+
+Label.form-error.visible {
+  display: block;
 }
 
 Static#logo {

--- a/dokli/tui/engine/__init__.py
+++ b/dokli/tui/engine/__init__.py
@@ -4,7 +4,7 @@ Parses the OpenAPI document into an entity registry so the TUI can render
 generic list/detail/form views for any Dokploy API version.
 """
 
-from dokli.tui.engine.icons import entity_icon, entity_icon_color, icon_label
+from dokli.tui.engine.icons import entity_icon, entity_icon_color, icon_label, state_color, state_indicator
 from dokli.tui.engine.introspect import (
     collect_children,
     field_label,
@@ -60,4 +60,6 @@ __all__ = [
     "record_title",
     "related_records",
     "related_spec",
+    "state_color",
+    "state_indicator",
 ]

--- a/dokli/tui/engine/__init__.py
+++ b/dokli/tui/engine/__init__.py
@@ -4,7 +4,7 @@ Parses the OpenAPI document into an entity registry so the TUI can render
 generic list/detail/form views for any Dokploy API version.
 """
 
-from dokli.tui.engine.icons import entity_icon
+from dokli.tui.engine.icons import entity_icon, entity_icon_color, icon_label
 from dokli.tui.engine.introspect import (
     collect_children,
     field_label,
@@ -46,7 +46,9 @@ __all__ = [
     "clear_probe_cache",
     "collect_children",
     "entity_icon",
+    "entity_icon_color",
     "field_label",
+    "icon_label",
     "infer_columns",
     "key_for_verb",
     "nested_child_entity",

--- a/dokli/tui/engine/icons.py
+++ b/dokli/tui/engine/icons.py
@@ -34,39 +34,39 @@ ENTITY_ICONS = {
 
 FALLBACK_ICON = "\uf15b"  # fa-file
 
-DEFAULT_ICON_COLOR = "grey70"
+DEFAULT_ICON_COLOR = "#6c7086"  # catppuccin overlay0
 
-# A distinct color per entity so icons are easy to tell apart.
+# A distinct Catppuccin color per entity so icons are easy to tell apart.
 ENTITY_ICON_COLORS = {
-    "project": "yellow",
-    "compose": "cyan",
-    "application": "magenta",
-    "postgres": "blue",
-    "mysql": "cyan",
-    "mariadb": "cyan",
-    "mongo": "green",
-    "redis": "red",
-    "libsql": "blue",
-    "server": "green",
-    "domain": "blue",
-    "deployment": "magenta",
-    "user": "blue",
-    "notification": "yellow",
-    "backup": "blue",
-    "sshKey": "yellow",
-    "environment": "magenta",
-    "docker": "cyan",
-    "registry": "yellow",
-    "tag": "cyan",
-    "organization": "magenta",
-    "certificate": "yellow",
-    "settings": "grey",
-    "port": "green",
-    "mount": "blue",
-    "gitea": "grey",
-    "github": "grey",
-    "gitlab": "grey",
-    "bitbucket": "grey",
+    "project": "#f9e2af",  # yellow
+    "compose": "#94e2d5",  # teal
+    "application": "#f5c2e7",  # pink
+    "postgres": "#89b4fa",  # blue
+    "mysql": "#94e2d5",  # teal
+    "mariadb": "#94e2d5",  # teal
+    "mongo": "#a6e3a1",  # green
+    "redis": "#f38ba8",  # red
+    "libsql": "#89b4fa",  # blue
+    "server": "#a6e3a1",  # green
+    "domain": "#89dceb",  # sky
+    "deployment": "#cba6f7",  # mauve
+    "user": "#89b4fa",  # blue
+    "notification": "#fab387",  # peach
+    "backup": "#89b4fa",  # blue
+    "sshKey": "#f9e2af",  # yellow
+    "environment": "#f5c2e7",  # pink
+    "docker": "#94e2d5",  # teal
+    "registry": "#fab387",  # peach
+    "tag": "#94e2d5",  # teal
+    "organization": "#cba6f7",  # mauve
+    "certificate": "#f9e2af",  # yellow
+    "settings": "#7f849c",  # overlay1
+    "port": "#a6e3a1",  # green
+    "mount": "#89b4fa",  # blue
+    "gitea": "#7f849c",  # overlay1
+    "github": "#7f849c",  # overlay1
+    "gitlab": "#7f849c",  # overlay1
+    "bitbucket": "#7f849c",  # overlay1
 }
 
 
@@ -85,18 +85,18 @@ def icon_label(name: str) -> str:
     return f"[b on {entity_icon_color(name)}] {entity_icon(name)} [/]"
 
 
-# Container/docker states -> traffic-light color.
+# Container/docker states -> Catppuccin traffic-light color.
 _STATE_COLORS = {
-    "running": "green",
-    "paused": "yellow",
-    "restarting": "yellow",
-    "created": "yellow",
-    "exited": "red",
-    "dead": "red",
-    "removing": "red",
-    "removed": "red",
-    "killed": "red",
-    "stopped": "red",
+    "running": "#a6e3a1",  # green
+    "paused": "#f9e2af",  # yellow
+    "restarting": "#f9e2af",  # yellow
+    "created": "#f9e2af",  # yellow
+    "exited": "#f38ba8",  # red
+    "dead": "#f38ba8",  # red
+    "removing": "#f38ba8",  # red
+    "removed": "#f38ba8",  # red
+    "killed": "#f38ba8",  # red
+    "stopped": "#f38ba8",  # red
 }
 
 

--- a/dokli/tui/engine/icons.py
+++ b/dokli/tui/engine/icons.py
@@ -36,6 +36,9 @@ FALLBACK_ICON = "\uf15b"  # fa-file
 
 DEFAULT_ICON_COLOR = "#6c7086"  # catppuccin overlay0
 
+# Dark glyph on the pastel colored boxes so the icon stays readable.
+ICON_FOREGROUND = "#1e1e2e"  # catppuccin base
+
 # A distinct Catppuccin color per entity so icons are easy to tell apart.
 ENTITY_ICON_COLORS = {
     "project": "#f9e2af",  # yellow
@@ -82,7 +85,7 @@ def entity_icon_color(name: str) -> str:
 
 def icon_label(name: str) -> str:
     """Rich markup for an entity icon inside a colored box."""
-    return f"[b on {entity_icon_color(name)}] {entity_icon(name)} [/]"
+    return f"[b {ICON_FOREGROUND} on {entity_icon_color(name)}] {entity_icon(name)} [/]"
 
 
 # Container/docker states -> Catppuccin traffic-light color.

--- a/dokli/tui/engine/icons.py
+++ b/dokli/tui/engine/icons.py
@@ -34,7 +34,52 @@ ENTITY_ICONS = {
 
 FALLBACK_ICON = "\uf15b"  # fa-file
 
+DEFAULT_ICON_COLOR = "grey70"
+
+# A distinct color per entity so icons are easy to tell apart.
+ENTITY_ICON_COLORS = {
+    "project": "yellow",
+    "compose": "cyan",
+    "application": "magenta",
+    "postgres": "blue",
+    "mysql": "cyan",
+    "mariadb": "cyan",
+    "mongo": "green",
+    "redis": "red",
+    "libsql": "blue",
+    "server": "green",
+    "domain": "blue",
+    "deployment": "magenta",
+    "user": "blue",
+    "notification": "yellow",
+    "backup": "blue",
+    "sshKey": "yellow",
+    "environment": "magenta",
+    "docker": "cyan",
+    "registry": "yellow",
+    "tag": "cyan",
+    "organization": "magenta",
+    "certificate": "yellow",
+    "settings": "grey",
+    "port": "green",
+    "mount": "blue",
+    "gitea": "grey",
+    "github": "grey",
+    "gitlab": "grey",
+    "bitbucket": "grey",
+}
+
 
 def entity_icon(name: str) -> str:
     """Return the Nerd Font icon for an entity (with a fallback)."""
     return ENTITY_ICONS.get(name, FALLBACK_ICON)
+
+
+def entity_icon_color(name: str) -> str:
+    """Return the color for an entity's icon."""
+    return ENTITY_ICON_COLORS.get(name, DEFAULT_ICON_COLOR)
+
+
+def icon_label(name: str) -> str:
+    """Rich markup for an entity icon inside a colored box."""
+    return f"[b on {entity_icon_color(name)}] {entity_icon(name)} [/]"

--- a/dokli/tui/engine/icons.py
+++ b/dokli/tui/engine/icons.py
@@ -83,3 +83,28 @@ def entity_icon_color(name: str) -> str:
 def icon_label(name: str) -> str:
     """Rich markup for an entity icon inside a colored box."""
     return f"[b on {entity_icon_color(name)}] {entity_icon(name)} [/]"
+
+
+# Container/docker states -> traffic-light color.
+_STATE_COLORS = {
+    "running": "green",
+    "paused": "yellow",
+    "restarting": "yellow",
+    "created": "yellow",
+    "exited": "red",
+    "dead": "red",
+    "removing": "red",
+    "removed": "red",
+    "killed": "red",
+    "stopped": "red",
+}
+
+
+def state_color(state: str) -> str:
+    """Traffic-light color for a container state."""
+    return _STATE_COLORS.get(state.lower(), DEFAULT_ICON_COLOR) if state else DEFAULT_ICON_COLOR
+
+
+def state_indicator(state: str) -> str:
+    """Rich markup dot (traffic light) colored by the container state."""
+    return f"[bold {state_color(state)}]●[/]"

--- a/dokli/tui/engine/related.py
+++ b/dokli/tui/engine/related.py
@@ -9,58 +9,64 @@ OpenAPI document does not express these relations, so they are declared here.
 
 import httpx
 
+from dokli.tui.engine.introspect import record_id
 from dokli.tui.engine.spec import EntityRegistry
 
 # Parent entity -> provider spec that enumerates its related records.
 #   entity: provider entity (e.g. docker), verb: action to call,
 #   fill: {provider param: record field}, label: section title in the UI.
+# The ``appName`` param is the docker *project* name: ``compose.one`` exposes it
+# as ``appName`` (a slug like ``media-torrents-92opw6``), which is what the
+# containers endpoint matches against. Composes also need ``appType`` from their
+# ``composeType``. List-level records lack these fields, so ``related_records``
+# enriches them via the entity's ``one`` action first.
 RELATED_PROVIDERS: dict[str, dict] = {
     "compose": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "appType": "composeType", "serverId": "serverId"},
         "label": "Containers",
     },
     "application": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
     "postgres": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
     "mysql": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
     "mariadb": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
     "mongo": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
     "redis": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
     "libsql": {
         "entity": "docker",
         "verb": "getContainersByAppNameMatch",
-        "fill": {"appName": "name", "serverId": "serverId"},
+        "fill": {"appName": "appName", "serverId": "serverId"},
         "label": "Containers",
     },
 }
@@ -86,8 +92,10 @@ def param_source(param: str) -> dict | None:
 def related_records(client, registry: EntityRegistry, parent_entity: str, record: dict) -> list[dict]:
     """Fetch the related records of a parent record.
 
-    Returns a list of records (each carrying its own id field), or ``[]`` when
-    the entity has no provider or the lookup fails.
+    The record is enriched via the entity's ``one`` action when it lacks the
+    fields the provider needs (e.g. the docker project ``appName``). Returns a
+    list of records (each carrying its own id field), or ``[]`` when the entity
+    has no provider or the lookup fails.
     """
     spec = RELATED_PROVIDERS.get(parent_entity)
     if spec is None:
@@ -96,7 +104,10 @@ def related_records(client, registry: EntityRegistry, parent_entity: str, record
     action = entity.get(spec["verb"]) if entity else None
     if action is None:
         return []
-    params = {param: record[field] for param, field in spec["fill"].items() if record.get(field)}
+    record = _enrich_record(client, registry, parent_entity, record, spec["fill"])
+    params = _build_params(record, spec["fill"])
+    if not params:
+        return []
     try:
         data = client.request("GET", action.route, params).json()
     except httpx.HTTPError:
@@ -105,3 +116,41 @@ def related_records(client, registry: EntityRegistry, parent_entity: str, record
         return [item for item in data if isinstance(item, dict)]
     items = data.get("items", []) if isinstance(data, dict) else []
     return [item for item in items if isinstance(item, dict)]
+
+
+def _build_params(record: dict, fill: dict) -> dict:
+    """Fill provider params from the record, falling back ``appName`` to ``name``."""
+    params = {}
+    for param, field in fill.items():
+        value = record.get(field)
+        if not value and param == "appName":
+            value = record.get("name")
+        if value:
+            params[param] = value
+    return params
+
+
+def _enrich_record(client, registry: EntityRegistry, parent_entity: str, record: dict, fill: dict) -> dict:
+    """Merge in the entity's ``one`` record when fill fields are missing."""
+    for field in fill.values():
+        if record.get(field):
+            continue
+        entity = registry.get(parent_entity)
+        one = entity.get("one") if entity else None
+        if one is None:
+            return record
+        params = {}
+        for param in one.param_names:
+            value = record.get(param) or record_id(record, parent_entity)
+            if value:
+                params[param] = value
+        if not params:
+            return record
+        try:
+            enriched = client.request("GET", one.route, params).json()
+        except httpx.HTTPError:
+            return record
+        if isinstance(enriched, dict):
+            return {**record, **enriched}
+        return record
+    return record

--- a/dokli/tui/engine/spec.py
+++ b/dokli/tui/engine/spec.py
@@ -156,6 +156,7 @@ VERB_KEYS = {
     "redeploy": "X",
     "testConnection": "t",
     "restart": "R",
+    "readLogs": "l",
 }
 
 
@@ -212,9 +213,7 @@ def parse_spec(schema: dict) -> EntityRegistry:
                 summary=(details.get("summary") or details.get("description") or "").strip(),
                 request_schema=_extract_request_schema(details),
                 param_names=[parameter["name"] for parameter in parameters],
-                required_params=[
-                    parameter["name"] for parameter in parameters if parameter.get("required")
-                ],
+                required_params=[parameter["name"] for parameter in parameters if parameter.get("required")],
             )
             entity = registry.entities.setdefault(entity_name, Entity(name=entity_name))
             entity.actions[verb] = action

--- a/dokli/tui/engine/spec.py
+++ b/dokli/tui/engine/spec.py
@@ -141,6 +141,10 @@ def classify(action: EntityAction) -> str:
 # Keys used by the browser navigation; never assigned to actions.
 RESERVED_KEYS = frozenset("hjklrq")
 
+# Keys reserved for app-level bindings (e.g. D toggles dark mode); never
+# assigned to actions so the app shortcuts are not overshadowed.
+SYSTEM_KEYS = frozenset("D")
+
 # Fallback key space, in priority order: letters, then digits, then uppercase.
 FALLBACK_KEYS = string.ascii_lowercase + string.digits + string.ascii_uppercase
 
@@ -156,7 +160,7 @@ VERB_KEYS = {
     "redeploy": "X",
     "testConnection": "t",
     "restart": "R",
-    "readLogs": "l",
+    "readLogs": "L",
 }
 
 
@@ -166,13 +170,13 @@ def key_for_verb(verb: str, taken: frozenset[str] = frozenset()) -> str | None:
     Prefers the verb's own letters (``VERB_KEYS`` first), then any free letter
     of the alphabet, so every action can get a key.
     """
-    if verb in VERB_KEYS and VERB_KEYS[verb] not in taken:
+    if verb in VERB_KEYS and VERB_KEYS[verb] not in taken and VERB_KEYS[verb] not in SYSTEM_KEYS:
         return VERB_KEYS[verb]
     for character in verb:
         if character.isalpha() and character.lower() not in taken and character.lower() not in RESERVED_KEYS:
             return character.lower()
     for character in FALLBACK_KEYS:
-        if character not in taken and character not in RESERVED_KEYS:
+        if character not in taken and character not in RESERVED_KEYS and character not in SYSTEM_KEYS:
             return character
     return None
 

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -386,9 +386,5 @@ class Form(Generic[M], Container):
             field.error = error
 
     def _get_form_data(self) -> dict[str, Any]:
-        data = {
-            child.id: child.get_data()
-            for child in self.children
-            if child.id and isinstance(child, FormControl)
-        }
+        data = {child.id: child.get_data() for child in self.children if child.id and isinstance(child, FormControl)}
         return data

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -273,6 +273,7 @@ class Form(Generic[M], Container):
 
     data: reactive[dict[str, Any]] = reactive(dict)
     model: reactive[type[M] | None] = reactive(None)
+    error: reactive[str | None] = reactive(None)
     cleaned_data: dict[str, Any] | None = None
     instance: M | None = None
 
@@ -293,6 +294,19 @@ class Form(Generic[M], Container):
         self.model = model if not instance else type(instance)
         self.cleaned_data = None
         self.validate_on_input = validate_on_input
+
+    async def on_mount(self) -> None:
+        """On mount, add the form-level error label."""
+        self._error_label = Label("", classes="form-error")
+        await self.mount(self._error_label)
+
+    def watch_error(self, old_value: str | None, new_value: str | None) -> None:
+        """Show or hide the form-level error message."""
+        label = getattr(self, "_error_label", None)
+        if label is None:
+            return
+        label.update(new_value or "")
+        label.set_class(bool(new_value), "visible")
 
     @classmethod
     def from_model(
@@ -343,6 +357,7 @@ class Form(Generic[M], Container):
         """Validate form data against model, if any."""
         data = self._get_form_data()
         self.reset(reset_value=False)
+        self.error = None
         if not self.model:
             self.cleaned_data = data
             return True
@@ -380,8 +395,13 @@ class Form(Generic[M], Container):
 
     def _set_errors(self, errors: list[ErrorDetails]) -> None:
         for error in errors:
-            loc = str(error["loc"][-1])
-            field = self.fields.get(loc)
+            loc = error["loc"]
+            if not loc:
+                # Model-level validation error (e.g. a cross-field validator
+                # like "provide api_key or api_key_cmd"); no field to attach to.
+                self.error = error["msg"].removeprefix("Value error, ")
+                continue
+            field = self.fields.get(str(loc[-1]))
             assert field, f"Unknown field: {loc}"
             field.error = error
 

--- a/dokli/tui/screens/connections.py
+++ b/dokli/tui/screens/connections.py
@@ -53,6 +53,7 @@ class ConnectionsScreen(Screen):
         """Update connection message."""
 
         connection: ConnectionConfig
+        original: ConnectionConfig | None = None
 
     @dataclass
     class DeleteConnection(Message):
@@ -97,6 +98,7 @@ class ConnectionsScreen(Screen):
             self._show_connection_screen(event.button.parent.connection)
 
     def _show_connection_screen(self, connection: ConnectionConfig | None = None) -> None:
+        self._editing_connection = connection
         detail = ConnectionScreen(connection)
         self.app.push_screen(detail, self._edit_connection_callback)
 
@@ -120,7 +122,9 @@ class ConnectionsScreen(Screen):
         if not result or not result.connection:
             return
         message = (
-            self.UpdateConnection(result.connection) if not result.delete else self.DeleteConnection(result.connection)
+            self.UpdateConnection(result.connection, self._editing_connection)
+            if not result.delete
+            else self.DeleteConnection(result.connection)
         )
         log("message", message)
         self.post_message(message)

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -69,7 +69,7 @@ class BrowserScreen(Screen):
         Binding("h", "left", "Parent"),
         Binding("l", "right", "Child", show=False),
         Binding("right", "right", "Child", show=False),
-        Binding("r", "refresh", "Refresh"),
+        Binding("f5", "refresh", "Refresh"),
         Binding("/", "filter", "Filter"),
         Binding("escape", "cancel", "Back"),
         Binding("q", "quit", "Quit"),

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -453,10 +453,10 @@ class BrowserScreen(Screen):
 
     def _run_action(self, action) -> None:
         if classify(action) == "form":
-            self.run_worker(self._open_form(action), exclusive=True)  # type: ignore[arg-type]
+            self.run_worker(self._open_form(action), exclusive=True, group="action")  # type: ignore[arg-type]
             return
         if action.method == "GET":
-            self.run_worker(self._show_result(action), exclusive=True)  # type: ignore[arg-type]
+            self.run_worker(self._show_result(action), exclusive=True, group="action")  # type: ignore[arg-type]
             return
         body = {}
         schema = action.request_schema

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -533,7 +533,9 @@ class BrowserScreen(Screen):
             return
         data = await self._api_get(action, params)
         if data is not None:
-            self.app.push_screen(ResultScreen(self.connection, action, data, classes="Entities"))
+            self.app.push_screen(
+                ResultScreen(self.connection, action, data, params=params, classes="Entities")
+            )
 
     async def _resolve_missing(self, action, params: dict, missing: list[str]) -> None:
         """Satisfy missing required params (e.g. containerId) via a picker."""

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -169,7 +169,7 @@ class BrowserScreen(Screen):
             return f"{entity_icon(title)}  {title}"
         if level.kind == "children":
             return f"{entity_icon(item.get('_kind') or '')}  {title}"
-        return title
+        return f"{entity_icon(level.kind)}  {title}"
 
     def _visible_items(self, level: Level) -> list[dict]:
         items = level.items
@@ -218,13 +218,14 @@ class BrowserScreen(Screen):
             widgets.append(Label("(empty)", classes="field"))
         else:
             kind = self._selected_kind() or ""
-            if kind:
-                widgets.append(Label(f"{entity_icon(kind)}  {kind}", classes="title"))
+            header, title_key = self._record_header(selected, kind)
+            if header:
+                widgets.append(Label(header, classes="title"))
             widgets.append(Label(self._breadcrumb(), classes="subtitle"))
-            for key, value in selected.items():
-                if key in ("_kind", "id") or value in (None, [], {}):
-                    continue
-                widgets.append(Label(f"[b]{field_label(key)}:[/b] {self._fmt(value)}", classes="field"))
+            skip = {"_kind", "id"}
+            if title_key:
+                skip.add(title_key)
+            widgets.extend(self._detail_field_labels(selected, skip))
             children = collect_children(selected)
             if children:
                 widgets.append(Label(f"Children ({len(children)})", classes="section"))
@@ -248,6 +249,28 @@ class BrowserScreen(Screen):
                     for action, key in bindings:
                         widgets.append(Label(f"  [{'b'}]{key or '-'}[/] {action.verb}"))
         await container.mount(*widgets)
+
+    def _detail_field_labels(self, selected: dict, skip: set[str]) -> list[Label]:
+        """Field labels for a record, excluding the skip set and empty values."""
+        labels = []
+        for key, value in selected.items():
+            if key in skip or value in (None, [], {}):
+                continue
+            labels.append(Label(f"[b]{field_label(key)}:[/b] {self._fmt(value)}", classes="field"))
+        return labels
+
+    def _record_header(self, selected: dict, kind: str) -> tuple[str | None, str | None]:
+        """The detail header label and the title key to skip in the field list."""
+        title_key = next(
+            (key for key in ("name", "appName", "title", "label") if selected.get(key)),
+            None,
+        )
+        if not kind:
+            return None, title_key
+        header = f"{entity_icon(kind)}  {kind}"
+        if title_key:
+            header += f"  [b]·  {self._fmt(selected[title_key])}[/b]"
+        return header, title_key
 
     def _entity_bindings(self, entity) -> list:
         """Action keybindings for an entity.

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -26,6 +26,7 @@ from dokli.tui.engine import (
     record_title,
     related_records,
     related_spec,
+    state_indicator,
 )
 from dokli.tui.screens.generic.execute import confirm_and_run
 from dokli.tui.screens.generic.form import ActionFormScreen
@@ -51,6 +52,9 @@ class BrowserScreen(Screen):
     """3-column browser: parent | current | detail+actions."""
 
     CSS = """
+    #parent-pane { width: 2fr; }
+    #current-pane { width: 2fr; }
+    #detail-pane { width: 4fr; }
     #current-pane > .selected, #parent-pane > .selected {
         background: $primary;
         color: $text;
@@ -238,9 +242,10 @@ class BrowserScreen(Screen):
                 widgets.append(Label(f"{label} ({len(related)})", classes="section"))
                 for item in related[:10]:
                     title = item.get("name") or record_id(item) or "?"
-                    status = item.get("state") or item.get("status")
-                    suffix = f" ({status})" if status else ""
-                    widgets.append(Label(f"  {icon_label('docker')}  {title}{suffix}"))
+                    state = item.get("state") or ""
+                    status = item.get("status") or ""
+                    suffix = f" ({state})" if state else (f" ({status})" if status else "")
+                    widgets.append(Label(f"  {state_indicator(state)} {title}{suffix}"))
         await container.mount(*widgets)
 
     def _detail_field_labels(self, selected: dict, skip: set[str]) -> list[Label]:
@@ -567,9 +572,7 @@ class BrowserScreen(Screen):
         params[missing[0]] = value
         data = await self._api_get(action, params)
         if data is not None:
-            self.app.push_screen(
-                ResultScreen(self.connection, action, data, params=params, classes="Entities")
-            )
+            self.app.push_screen(ResultScreen(self.connection, action, data, params=params, classes="Entities"))
 
     async def _open_form(self, action) -> None:
         """Open an action form.

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -108,6 +108,19 @@ class BrowserScreen(Screen):
         """On mount, probe which entities are usable with this API key."""
         await self._run_reprobe()
 
+    def reload(self, connection: ConnectionConfig, registry: EntityRegistry) -> None:
+        """Point this browser at a new connection/registry and re-probe."""
+        self.connection = connection
+        self.registry = registry
+        self.client = APIClient(connection)
+        entities = [{"_kind": name, "name": name} for name in registry.listable()]
+        self.path = [Level(kind="entities", items=entities)]
+        self._filter = ""
+        self._usable = None
+        self._related_cache = {}
+        clear_probe_cache(connection.name)
+        self.run_worker(self._run_reprobe())  # type: ignore[arg-type]
+
     async def _run_reprobe(self) -> None:
         """Probe entity usability in a worker thread, then refresh the list."""
         results = await asyncio.to_thread(probe_entities, self.client, self.registry, self.connection.name)

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -264,6 +264,20 @@ class BrowserScreen(Screen):
             ]
         return bindings
 
+    def contextual_bindings(self) -> list[tuple[str, str]]:
+        """The current selection's action keybindings, for the help screen."""
+        entries: list[tuple[str, str]] = []
+        entity = self.registry.get(self._selected_kind() or "")
+        if entity is None:
+            return entries
+        selected = self.selected or {}
+        title = record_title(selected) if selected else ""
+        for action, key in self._entity_bindings(entity):
+            if key:
+                label = action.verb if not title else f"{action.verb} {title}"
+                entries.append((key, label))
+        return entries
+
     def _fmt(self, value) -> str:
         if isinstance(value, dict | list):
             return f"{type(value).__name__} ({len(value)})"
@@ -537,7 +551,9 @@ class BrowserScreen(Screen):
         params[missing[0]] = value
         data = await self._api_get(action, params)
         if data is not None:
-            self.app.push_screen(ResultScreen(self.connection, action, data, classes="Entities"))
+            self.app.push_screen(
+                ResultScreen(self.connection, action, data, params=params, classes="Entities")
+            )
 
     async def _open_form(self, action) -> None:
         """Open an action form.

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -18,8 +18,8 @@ from dokli.tui.engine import (
     classify,
     clear_probe_cache,
     collect_children,
-    entity_icon,
     field_label,
+    icon_label,
     param_source,
     probe_entities,
     record_id,
@@ -166,10 +166,10 @@ class BrowserScreen(Screen):
     def _item_label(self, item: dict, level: Level) -> str:
         title = record_title(item)
         if level.kind == "entities":
-            return f"{entity_icon(title)}  {title}"
+            return f"{icon_label(title)}  {title}"
         if level.kind == "children":
-            return f"{entity_icon(item.get('_kind') or '')}  {title}"
-        return f"{entity_icon(level.kind)}  {title}"
+            return f"{icon_label(item.get('_kind') or '')}  {title}"
+        return f"{icon_label(level.kind)}  {title}"
 
     def _visible_items(self, level: Level) -> list[dict]:
         items = level.items
@@ -230,7 +230,7 @@ class BrowserScreen(Screen):
             if children:
                 widgets.append(Label(f"Children ({len(children)})", classes="section"))
                 for child_entity, child in children[:10]:
-                    widgets.append(Label(f"  {entity_icon(child_entity)}  {record_title(child)}"))
+                    widgets.append(Label(f"  {icon_label(child_entity)}  {record_title(child)}"))
             related = self._related_records(selected)
             if related:
                 spec = related_spec(kind)
@@ -240,14 +240,7 @@ class BrowserScreen(Screen):
                     title = item.get("name") or record_id(item) or "?"
                     status = item.get("state") or item.get("status")
                     suffix = f" ({status})" if status else ""
-                    widgets.append(Label(f"  {entity_icon('docker')}  {title}{suffix}"))
-            entity = self.registry.get(kind)
-            if entity:
-                bindings = self._entity_bindings(entity)
-                if bindings:
-                    widgets.append(Label("Actions", classes="section"))
-                    for action, key in bindings:
-                        widgets.append(Label(f"  [{'b'}]{key or '-'}[/] {action.verb}"))
+                    widgets.append(Label(f"  {icon_label('docker')}  {title}{suffix}"))
         await container.mount(*widgets)
 
     def _detail_field_labels(self, selected: dict, skip: set[str]) -> list[Label]:
@@ -267,7 +260,7 @@ class BrowserScreen(Screen):
         )
         if not kind:
             return None, title_key
-        header = f"{entity_icon(kind)}  {kind}"
+        header = f"{icon_label(kind)}  {kind}"
         if title_key:
             header += f"  [b]·  {self._fmt(selected[title_key])}[/b]"
         return header, title_key

--- a/dokli/tui/screens/generic/confirm.py
+++ b/dokli/tui/screens/generic/confirm.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from textual.binding import Binding
+from textual.containers import Horizontal
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, Label
 
@@ -35,8 +36,11 @@ class ConfirmScreen(Screen):
         yield Footer()
         yield Label(self._title, id="title", classes="title")
         yield Label(self._message, id="message")
-        yield Button("Yes", id="yes", variant="error" if self._danger else "primary")
-        yield Button("No", id="no")
+        yield Horizontal(
+            Button("Yes", id="yes", variant="error" if self._danger else "primary"),
+            Button("No", id="no"),
+            classes="actions",
+        )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle buttons."""

--- a/dokli/tui/screens/generic/execute.py
+++ b/dokli/tui/screens/generic/execute.py
@@ -18,11 +18,7 @@ def build_body(action: EntityAction, data: dict) -> dict:
     for key, raw_value in data.items():
         if raw_value in ("", None):
             continue
-        value = (
-            raw_value.get_secret_value()
-            if isinstance(raw_value, SecretStr | SecretBytes)
-            else raw_value
-        )
+        value = raw_value.get_secret_value() if isinstance(raw_value, SecretStr | SecretBytes) else raw_value
         body[key] = value
     return body
 

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -90,9 +90,7 @@ class ActionFormScreen(Screen):
 
     def action_wizard(self) -> None:
         """Open the step-by-step wizard for the same action."""
-        self.app.push_screen(
-            WizardScreen(self.connection, self.action, record=self.record, classes="Entities")
-        )
+        self.app.push_screen(WizardScreen(self.connection, self.action, record=self.record, classes="Entities"))
 
     def action_cancel(self) -> None:
         """Cancel the form."""

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from textual.binding import Binding
+from textual.containers import Horizontal
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header
 
@@ -47,9 +48,12 @@ class ActionFormScreen(Screen):
         yield Header()
         yield Footer()
         yield self.form
-        yield Button("Submit", id="submit", variant="primary")
-        yield Button("Wizard mode", id="wizard")
-        yield Button("Cancel", id="cancel")
+        yield Horizontal(
+            Button("Submit", id="submit", variant="primary"),
+            Button("Wizard mode", id="wizard"),
+            Button("Cancel", id="cancel"),
+            classes="actions",
+        )
 
     def on_screen_resume(self, event) -> None:
         """On screen resume."""

--- a/dokli/tui/screens/generic/help.py
+++ b/dokli/tui/screens/generic/help.py
@@ -38,10 +38,14 @@ class HelpScreen(Screen):
         sources = []
         previous = self.app.screen_stack[-2] if len(self.app.screen_stack) >= 2 else None
         if previous is not None:
-            sources.append((type(previous).__name__, previous.BINDINGS))
-        sources.append(("App", self.app.BINDINGS))
-        for title, bindings in sources:
+            sources.append(
+                (type(previous).__name__, previous.BINDINGS, getattr(previous, "contextual_bindings", None))
+            )
+        sources.append(("App", self.app.BINDINGS, None))
+        for title, bindings, contextual in sources:
             entries = _binding_entries(bindings)
+            if contextual is not None:
+                entries.extend(contextual())
             if not entries:
                 continue
             widgets.append(Label(title, classes="section"))

--- a/dokli/tui/screens/generic/help.py
+++ b/dokli/tui/screens/generic/help.py
@@ -43,19 +43,28 @@ class HelpScreen(Screen):
             )
         sources.append(("App", self.app.BINDINGS, None))
         for title, bindings, contextual in sources:
-            entries = _binding_entries(bindings)
-            if contextual is not None:
-                entries.extend(contextual())
+            entries = _merge_entries(_binding_entries(bindings), contextual() if contextual else None)
             if not entries:
                 continue
             widgets.append(Label(title, classes="section"))
-            for key, description in dict(entries).items():
+            for key, description in entries:
                 widgets.append(Label(f"  [b]{key}[/b]  {description}"))
         await container.mount(*widgets)
 
     def action_close(self) -> None:
         """Close the help screen."""
         self.dismiss(None)
+
+
+def _merge_entries(
+    default: list[tuple[str, str]], contextual: list[tuple[str, str]] | None
+) -> list[tuple[str, str]]:
+    """Combine default and contextual bindings, default winning on collisions."""
+    merged: dict[str, str] = {}
+    for entries in (default, contextual or []):
+        for key, description in entries:
+            merged.setdefault(key, description)
+    return list(merged.items())
 
 
 def _binding_entries(bindings) -> list[tuple[str, str]]:

--- a/dokli/tui/screens/generic/help.py
+++ b/dokli/tui/screens/generic/help.py
@@ -30,6 +30,7 @@ class HelpScreen(Screen):
         """On screen resume."""
         self.app.sub_title = "Help"
         self.run_worker(self._render_items, exclusive=True)  # type: ignore[arg-type]
+
     async def _render_items(self) -> None:
         """Render the bindings of the app and the previous screen."""
         container = self.query_one("#help-scroll", VerticalScroll)
@@ -56,9 +57,7 @@ class HelpScreen(Screen):
         self.dismiss(None)
 
 
-def _merge_entries(
-    default: list[tuple[str, str]], contextual: list[tuple[str, str]] | None
-) -> list[tuple[str, str]]:
+def _merge_entries(default: list[tuple[str, str]], contextual: list[tuple[str, str]] | None) -> list[tuple[str, str]]:
     """Combine default and contextual bindings, default winning on collisions."""
     merged: dict[str, str] = {}
     for entries in (default, contextual or []):

--- a/dokli/tui/screens/generic/help.py
+++ b/dokli/tui/screens/generic/help.py
@@ -1,0 +1,70 @@
+"""Generic help screen: lists the keybindings of the app and active screen."""
+
+from typing import TYPE_CHECKING
+
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Label
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class HelpScreen(Screen):
+    """Show the keybindings for the app and the screen that requested help."""
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+        Binding("q", "close", "Close"),
+    ]
+
+    def compose(self) -> "ComposeResult":
+        """Compose the screen."""
+        yield Header()
+        yield Footer()
+        yield Label("Keybindings", classes="title")
+        yield VerticalScroll(id="help-scroll")
+
+    def on_screen_resume(self, event) -> None:
+        """On screen resume."""
+        self.app.sub_title = "Help"
+        self.run_worker(self._render_items, exclusive=True)  # type: ignore[arg-type]
+    async def _render_items(self) -> None:
+        """Render the bindings of the app and the previous screen."""
+        container = self.query_one("#help-scroll", VerticalScroll)
+        await container.remove_children()
+        widgets = []
+        sources = []
+        previous = self.app.screen_stack[-2] if len(self.app.screen_stack) >= 2 else None
+        if previous is not None:
+            sources.append((type(previous).__name__, previous.BINDINGS))
+        sources.append(("App", self.app.BINDINGS))
+        for title, bindings in sources:
+            entries = _binding_entries(bindings)
+            if not entries:
+                continue
+            widgets.append(Label(title, classes="section"))
+            for key, description in dict(entries).items():
+                widgets.append(Label(f"  [b]{key}[/b]  {description}"))
+        await container.mount(*widgets)
+
+    def action_close(self) -> None:
+        """Close the help screen."""
+        self.dismiss(None)
+
+
+def _binding_entries(bindings) -> list[tuple[str, str]]:
+    """Normalize BINDINGS (Binding or tuple entries) into (key, description)."""
+    entries = []
+    for binding in bindings:
+        if isinstance(binding, Binding):
+            key, description, show = binding.key, binding.description, binding.show
+        else:
+            parts = list(binding)
+            key = str(parts[0])
+            description = str(parts[2]) if len(parts) > 2 else ""
+            show = True
+        if show and description:
+            entries.append((key, description))
+    return entries

--- a/dokli/tui/screens/generic/result.py
+++ b/dokli/tui/screens/generic/result.py
@@ -2,11 +2,14 @@
 
 from typing import TYPE_CHECKING, Any
 
+import httpx
+from rich.text import Text
 from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.screen import Screen
-from textual.widgets import Footer, Header, Label
+from textual.widgets import Footer, Header, Input, Label
 
+from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.tui.engine import EntityAction, field_label
 
@@ -15,12 +18,27 @@ if TYPE_CHECKING:
 
 
 class ResultScreen(Screen):
-    """Show the result of a GET (query) action."""
+    """Show the result of a GET (query) action.
+
+    Press ``r`` to re-fetch the result, ``/`` to search within it: matches are
+    highlighted, the position is shown as ``N/M``, and ``n``/``N`` jump to the
+    next/previous match. Enter commits the search (blurs the input); escape
+    clears it.
+    """
+
+    CSS = """
+    #search-input { margin: 0 1; }
+    #match-status { margin: 0 1; }
+    """
 
     BINDINGS = [
         Binding("escape", "dismiss_screen", "Close"),
         Binding("q", "dismiss_screen", "Close"),
         Binding("enter", "dismiss_screen", "Close"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("/", "search", "Search"),
+        Binding("n", "next_match", "Next match"),
+        Binding("N", "prev_match", "Prev match"),
     ]
 
     def __init__(
@@ -28,6 +46,7 @@ class ResultScreen(Screen):
         connection: ConnectionConfig,
         action: EntityAction,
         data: Any,
+        params: dict | None = None,
         *args,
         **kwargs,
     ) -> None:
@@ -36,21 +55,170 @@ class ResultScreen(Screen):
         self.connection = connection
         self.action = action
         self.data = data
+        self.params = params or {}
+        self._lines: list[str] = []
+        self._query = ""
+        self._matches: list[int] = []
+        self._match_index = 0
+        self.search_input = Input(placeholder="Search...", id="search-input")
+        self.search_input.display = False
+        self.search_input.can_focus = False
 
     def compose(self) -> "ComposeResult":
         """Compose the screen."""
         yield Header()
         yield Footer()
         yield Label(f"{self.connection.name} · {self.action.route}", classes="title")
+        yield self.search_input
         yield VerticalScroll(Label(_render_data(self.data), id="result"), id="result-scroll")
+        yield Label("", id="match-status")
 
     def on_screen_resume(self, event) -> None:
         """On screen resume."""
         self.app.sub_title = f"{self.connection.name} - {self.action.route} result"
+        if not self._lines:
+            self._lines = _plain_lines(self.data)
+
+    def on_key(self, event) -> None:
+        """Intercept enter/escape while the search input is focused."""
+        search_input = self.search_input
+        if not (search_input.display and self.focused is search_input):
+            return
+        if event.key == "enter":
+            search_input.blur()
+            event.stop()
+        elif event.key == "escape":
+            self._clear_search()
+            event.stop()
+
+    # -- refresh -----------------------------------------------------------
+
+    def action_refresh(self) -> None:
+        """Re-fetch the result of the action."""
+        self.run_worker(self._refresh(), group="action")  # type: ignore[arg-type]
+
+    async def _refresh(self) -> None:
+        """Fetch fresh data and re-render (keeping any active search)."""
+        try:
+            response = APIClient(self.connection).request("GET", self.action.route, self.params)
+        except httpx.HTTPError as err:
+            self.notify(f"API error: {err}", severity="error", timeout=10)
+            return
+        self.data = response.json()
+        self._lines = _plain_lines(self.data)
+        self._recompute_matches()
+        await self._apply_search()
+
+    # -- search ------------------------------------------------------------
+
+    def action_search(self) -> None:
+        """Open the search input."""
+        self.search_input.can_focus = True
+        self.search_input.display = True
+        self.search_input.focus()
 
     def action_dismiss_screen(self) -> None:
-        """Close the result screen."""
+        """Clear the search if active, otherwise close the screen."""
+        search_input = self.search_input
+        if search_input.display and self.focused is not search_input:
+            self._clear_search()
+            return
         self.dismiss(None)
+
+    def action_next_match(self) -> None:
+        """Jump to the next match."""
+        if self._matches:
+            self._match_index = (self._match_index + 1) % len(self._matches)
+            self._apply_search_async()
+
+    def action_prev_match(self) -> None:
+        """Jump to the previous match."""
+        if self._matches:
+            self._match_index = (self._match_index - 1) % len(self._matches)
+            self._apply_search_async()
+
+    def on_input_changed(self, event) -> None:
+        """Live-search as the user types."""
+        if event.input.id != "search-input":
+            return
+        self._query = event.value
+        self._match_index = 0
+        self._recompute_matches()
+        self._apply_search_async()
+
+    def _recompute_matches(self) -> None:
+        """Recompute the match lines for the current query."""
+        self._matches = [
+            i for i, line in enumerate(self._lines) if self._query.lower() in line.lower()
+        ]
+        if self._matches:
+            self._match_index = min(self._match_index, len(self._matches) - 1)
+        else:
+            self._match_index = 0
+
+    def _apply_search_async(self) -> None:
+        """Schedule a re-render of the highlighted result."""
+        self.run_worker(self._apply_search(), exclusive=True, group="search")  # type: ignore[arg-type]
+
+    async def _apply_search(self) -> None:
+        """Render the result with the current matches highlighted."""
+        container = self.query_one("#result-scroll", VerticalScroll)
+        await container.remove_children()
+        if not self._query:
+            await container.mount(Label(_render_data(self.data), id="result"))
+            self._render_status()
+            return
+        widgets = [Label(self._highlight_line(line, i)) for i, line in enumerate(self._lines)]
+        await container.mount(*widgets)
+        self._scroll_to_current(container)
+        self._render_status()
+
+    def _highlight_line(self, line: str, line_index: int) -> Text:
+        """Highlight all occurrences of the query in a line."""
+        text = Text()
+        query = self._query.lower()
+        lower = line.lower()
+        start = 0
+        while True:
+            index = lower.find(query, start)
+            if index == -1:
+                text.append(line[start:])
+                break
+            text.append(line[start:index])
+            current = line_index == self._matches[self._match_index]
+            style = "bold reverse" if current else "bold yellow"
+            text.append(line[index : index + len(query)], style=style)
+            start = index + len(query)
+        return text
+
+    def _scroll_to_current(self, container: VerticalScroll) -> None:
+        """Scroll the current match into view."""
+        if not self._matches:
+            return
+        line_index = self._matches[self._match_index]
+        widgets = list(container.children)
+        if 0 <= line_index < len(widgets):
+            container.scroll_to_widget(widgets[line_index], animate=False)
+
+    def _render_status(self) -> None:
+        """Update the match counter label."""
+        status = self.query_one("#match-status", Label)
+        if not self._query:
+            status.update("")
+        elif not self._matches:
+            status.update("No matches")
+        else:
+            status.update(f"{self._match_index + 1}/{len(self._matches)} matches")
+
+    def _clear_search(self) -> None:
+        """Hide the search input and restore the plain result."""
+        search_input = self.search_input
+        search_input.display = False
+        search_input.value = ""
+        self._query = ""
+        self._matches = []
+        self._match_index = 0
+        self._apply_search_async()
 
 
 def _render_data(data: Any, indent: int = 0) -> str:
@@ -76,3 +244,32 @@ def _render_data(data: Any, indent: int = 0) -> str:
                 lines.append(f"{pad}- {item}")
         return "\n".join(lines)
     return f"{pad}{data}"
+
+
+def _plain_lines(data: Any, indent: int = 0) -> list[str]:
+    """Flatten data into plain text lines (logs are split by newline)."""
+    pad = "  " * indent
+    if isinstance(data, str):
+        if "\n" in data:
+            return [f"{pad}{line}" for line in data.split("\n")]
+        return [f"{pad}{data}"]
+    if isinstance(data, dict):
+        lines = []
+        for key, value in data.items():
+            if isinstance(value, dict | list):
+                lines.append(f"{pad}{field_label(key)}:")
+                lines.extend(_plain_lines(value, indent + 1))
+            else:
+                lines.append(f"{pad}{field_label(key)}: {value}")
+        return lines
+    if isinstance(data, list):
+        if not data:
+            return [f"{pad}(empty)"]
+        lines = []
+        for item in data:
+            if isinstance(item, dict | list):
+                lines.extend(_plain_lines(item, indent))
+            else:
+                lines.append(f"{pad}- {item}")
+        return lines
+    return [f"{pad}{data}"]

--- a/dokli/tui/screens/generic/result.py
+++ b/dokli/tui/screens/generic/result.py
@@ -148,9 +148,7 @@ class ResultScreen(Screen):
 
     def _recompute_matches(self) -> None:
         """Recompute the match lines for the current query."""
-        self._matches = [
-            i for i, line in enumerate(self._lines) if self._query.lower() in line.lower()
-        ]
+        self._matches = [i for i, line in enumerate(self._lines) if self._query.lower() in line.lower()]
         if self._matches:
             self._match_index = min(self._match_index, len(self._matches) - 1)
         else:

--- a/dokli/tui/screens/generic/result.py
+++ b/dokli/tui/screens/generic/result.py
@@ -35,7 +35,7 @@ class ResultScreen(Screen):
         Binding("escape", "dismiss_screen", "Close"),
         Binding("q", "dismiss_screen", "Close"),
         Binding("enter", "dismiss_screen", "Close"),
-        Binding("r", "refresh", "Refresh"),
+        Binding("f5", "refresh", "Refresh"),
         Binding("/", "search", "Search"),
         Binding("n", "next_match", "Next match"),
         Binding("N", "prev_match", "Prev match"),

--- a/dokli/tui/screens/generic/result.py
+++ b/dokli/tui/screens/generic/result.py
@@ -186,7 +186,7 @@ class ResultScreen(Screen):
                 break
             text.append(line[start:index])
             current = line_index == self._matches[self._match_index]
-            style = "bold reverse" if current else "bold yellow"
+            style = "bold reverse" if current else "#f9e2af"
             text.append(line[index : index + len(query)], style=style)
             start = index + len(query)
         return text

--- a/dokli/tui/screens/generic/wizard.py
+++ b/dokli/tui/screens/generic/wizard.py
@@ -41,8 +41,7 @@ class WizardScreen(Screen):
         self.model = build_form_model(action.request_schema, name=f"{action.route}Wizard")
         self.fields = list(self.model.model_fields.items())
         self.controls = {
-            name: FormControl.from_field(name, field, value=self.record.get(name))
-            for name, field in self.fields
+            name: FormControl.from_field(name, field, value=self.record.get(name)) for name, field in self.fields
         }
         self.index = 0
 
@@ -79,9 +78,7 @@ class WizardScreen(Screen):
         container = self.query_one("#control", Container)
         container.remove_children()
         container.mount(control)
-        self.query_one("#prompt", Label).update(
-            f"({self.index + 1}/{len(self.fields)}) {field.title or name}"
-        )
+        self.query_one("#prompt", Label).update(f"({self.index + 1}/{len(self.fields)}) {field.title or name}")
         control.focus()
 
     def action_next(self) -> None:

--- a/dokli/tui/screens/generic/wizard.py
+++ b/dokli/tui/screens/generic/wizard.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING
 
 from textual.binding import Binding
-from textual.containers import Container
+from textual.containers import Container, Horizontal
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, Label
 
@@ -52,9 +52,12 @@ class WizardScreen(Screen):
         yield Footer()
         yield Label("", id="prompt", classes="title")
         yield Container(id="control")
-        yield Button("Back", id="back")
-        yield Button("Next", id="next", variant="primary")
-        yield Button("Cancel", id="cancel")
+        yield Horizontal(
+            Button("Back", id="back"),
+            Button("Next", id="next", variant="primary"),
+            Button("Cancel", id="cancel"),
+            classes="actions",
+        )
 
     def on_screen_resume(self, event) -> None:
         """On screen resume."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,22 @@ class TestConfig:
         assert [c.name for c in reloaded] == ["meche", "stage"]
         assert reloaded[1].api_key.get_secret_value() == "*" * 64
 
+    def test_config_path_prefers_local(self, tmp_path, monkeypatch):
+        """We expect a local dokli.yaml in the cwd to be the save target."""
+        (tmp_path / "dokli.yaml").write_text("connections: []\n")
+        monkeypatch.chdir(tmp_path)
+        config = ConfigFactory.build()
+        assert config._config_path().resolve() == (tmp_path / "dokli.yaml").resolve()
+
+    def test_save_uses_local_file(self, tmp_path, monkeypatch):
+        """We expect save() without a path to write to the local dokli.yaml."""
+        (tmp_path / "dokli.yaml").write_text("connections: []\n")
+        monkeypatch.chdir(tmp_path)
+        config = ConfigFactory.build(connections=[ConnectionConfigFactory.build(name="meche")])
+        config.save()
+        data = yaml.safe_load((tmp_path / "dokli.yaml").read_text())
+        assert data["connections"][0]["name"] == "meche"
+
 
 class TestConnectionConfig:
     """Connection config model tests."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Config tests."""
 
+import yaml
 import pytest
 from polyfactory.factories.pydantic_factory import ModelFactory
 from pydantic import ValidationError
@@ -33,6 +34,26 @@ class TestConfig:
         connection = ConnectionConfigFactory.build(name="dokploy")
         config = ConfigFactory.build(connections=[connection])
         assert config.get_connection("dokploy")
+
+    def test_save_round_trip(self, tmp_path):
+        """We expect save() to persist connections and reload them."""
+        target = tmp_path / "dokli.yaml"
+        config = ConfigFactory.build(
+            connections=[
+                ConnectionConfigFactory.build(name="meche", api_key_cmd="echo key"),
+                ConnectionConfigFactory.build(name="stage", api_key="*" * 64),
+            ]
+        )
+        config.save(target)
+
+        data = yaml.safe_load(target.read_text())
+        assert [c["name"] for c in data["connections"]] == ["meche", "stage"]
+        assert data["connections"][0]["api_key_cmd"] == "echo key"
+        assert data["connections"][1]["api_key"] == "*" * 64
+
+        reloaded = [ConnectionConfig.model_validate(c) for c in data["connections"]]
+        assert [c.name for c in reloaded] == ["meche", "stage"]
+        assert reloaded[1].api_key.get_secret_value() == "*" * 64
 
 
 class TestConnectionConfig:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -157,8 +157,9 @@ def _fake_requests():
         "compose.one": {
             "composeId": "c1",
             "name": "torrents",
-            "sourceType": "raw",
+            "appName": "media-torrents-abc123",
             "composeType": "docker-compose",
+            "sourceType": "raw",
             "composeFile": "version: '3'",
         },
         "docker.getContainersByAppNameMatch": [
@@ -765,6 +766,39 @@ def test_detail_shows_related_containers(mocker):
             ]
             assert any("Containers (2)" in label for label in detail)
             assert any("frigate" in label for label in detail)
+
+    _run(main())
+
+
+def test_related_containers_enrich_via_one(mocker):
+    """We expect the browser to enrich a compose record via one to get the docker
+    project name (appName) and appType before fetching its containers."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            screen = app.screen
+            screen.path = [
+                Level(
+                    kind="children",
+                    items=[{"_kind": "compose", "composeId": "c1", "name": "torrents"}],
+                    entity="compose",
+                )
+            ]
+            screen.current.index = 0
+            related = screen._related_records(screen.selected)
+            docker_call = next(
+                call
+                for call in screen.client.request.call_args_list
+                if call[0][1] == "docker.getContainersByAppNameMatch"
+            )
+            _, _, params = docker_call.args
+            assert params["appName"] == "media-torrents-abc123"
+            assert params["appType"] == "docker-compose"
+            assert [r["name"] for r in related] == ["frigate", "frigate-notify"]
 
     _run(main())
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -13,6 +13,7 @@ from dokli.tui.engine import build_form_model, clear_probe_cache, parse_spec, pr
 from dokli.tui.engine.spec import Entity, EntityAction
 from dokli.tui.forms import Form, SelectControl, SwitchControl, TextAreaControl
 from dokli.tui.screens.connections import ConnectionsScreen
+from dokli.tui.screens.connection import ConnectionScreen
 from dokli.tui.screens.generic.browser import BrowserScreen, Level
 from dokli.tui.screens.generic.confirm import ConfirmScreen
 from dokli.tui.screens.generic.form import ActionFormScreen
@@ -232,6 +233,49 @@ def test_form_prefills_from_data():
     model = build_form_model({"properties": {"name": {"type": "string"}}})
     form = Form.from_model(model, data={"name": "prefilled"})
     assert form.fields["name"].value == "prefilled"
+
+
+def test_form_surfaces_model_level_errors():
+    """We expect a cross-field model error (empty loc) not to crash and to be shown."""
+    form = Form.from_model(ConnectionConfig)
+    form._set_errors(
+        [
+            {
+                "loc": (),
+                "msg": "Must provide api_key or api_key_cmd.",
+                "type": "value_error",
+                "input": {"name": "hot-test", "api_key": None, "api_key_cmd": None},
+            }
+        ]
+    )
+    assert form.error == "Must provide api_key or api_key_cmd."
+
+
+def test_connection_form_model_error_no_crash(mocker):
+    """We expect typing in a new connection form not to crash on the model validator."""
+    mocker.patch("dokli.config.Config.save")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            screen.action_add_connection()
+            for _ in range(10):
+                await pilot.pause()
+            assert isinstance(app.screen, ConnectionScreen)
+            form = app.screen.query_one(Form)
+            form.fields["name"].value = "hot-test"
+            form.fields["url"].value = "https://storm.example.dev"
+            form.fields["notes"].value = "H"
+            form.validate()
+            assert form.error == "Must provide api_key or api_key_cmd."
+            # typing in notes triggers validation without crashing
+            form.fields["notes"].value = "HELLO"
+            form.validate()
+            assert form.error == "Must provide api_key or api_key_cmd."
+
+    _run(main())
 
 
 def test_form_rich_controls():
@@ -1150,9 +1194,7 @@ def test_help_screen_shows_bindings(mocker):
             # select 'project' so its contextual actions are available
             screen = app.screen
             vis = screen._visible_items(screen.current)
-            screen.current.index = next(
-                i for i, item in enumerate(vis) if item.get("name") == "project"
-            )
+            screen.current.index = next(i for i, item in enumerate(vis) if item.get("name") == "project")
             await pilot.pause()
             await pilot.press("?")
             for _ in range(10):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -733,7 +733,7 @@ def test_result_refresh_refetches(mocker):
             app.push_screen("result")
             await pilot.pause()
             await pilot.pause()
-            await pilot.press("r")
+            await pilot.press("f5")
             await pilot.pause()
             await pilot.pause()
             client.request.assert_called_once_with("GET", action.route, params)
@@ -1171,7 +1171,7 @@ def test_command_provider_lists_connections(mocker):
             assert "Help" in names
             assert "Quit" in names
             by_name = {hit.text: hit.help for hit in hits}
-            assert by_name["Toggle dark mode"] == "[d] Switch between light and dark themes"
+            assert by_name["Toggle dark mode"] == "[D] Switch between light and dark themes"
             assert by_name["Help"] == "[?] Show the keybindings"
 
     _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1160,6 +1160,9 @@ def test_command_provider_lists_connections(mocker):
             assert "Open test-env" in names
             assert "Help" in names
             assert "Quit" in names
+            by_name = {hit.text: hit.help for hit in hits}
+            assert by_name["Toggle dark mode"] == "[d] Switch between light and dark themes"
+            assert by_name["Help"] == "[?] Show the keybindings"
 
     _run(main())
 
@@ -1181,6 +1184,8 @@ def test_command_provider_lists_browser_actions(mocker):
             assert "Run create on project" in names
             assert "Run homeStats on project" in names
             assert not any(name == "Run remove on project" for name in names)
+            create_help = next(hit.help for hit in hits if hit.text == "Run create on project")
+            assert create_help == "[c] create · project (POST)"
 
     _run(main())
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -771,6 +771,8 @@ def test_read_logs_params_only_backfill_entity_id(mocker):
             assert isinstance(app.screen, ResultScreen)
             _, _, params = screen.client.request.call_args.args
             assert params == {"applicationId": "a1"}
+            # the result screen must keep the params so its refresh re-uses them
+            assert app.screen.params == {"applicationId": "a1"}
 
     _run(main())
 
@@ -1086,6 +1088,46 @@ def test_delete_connection_persists(mocker):
             await pilot.pause()
             app.on_connections_screen_delete_connection(ConnectionsScreen.DeleteConnection(connection=_connection()))
             assert app.config.connections == []
+            save.assert_called_once()
+
+    _run(main())
+
+
+def test_rename_connection_replaces_not_duplicates(mocker):
+    """We expect renaming a connection to replace it, not duplicate it."""
+    config = _config()
+    save = mocker.patch("dokli.config.Config.save")
+    renamed = ConnectionConfig(name="renamed", url="https://other.example.com", api_key_cmd="echo key")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_connections_screen_update_connection(
+                ConnectionsScreen.UpdateConnection(connection=renamed, original=_connection())
+            )
+            assert [c.name for c in app.config.connections] == ["renamed"]
+            save.assert_called_once()
+
+    _run(main())
+
+
+def test_connection_edit_syncs_screen(mocker):
+    """We expect the connections screen list to refresh after an edit."""
+    config = _config()
+    save = mocker.patch("dokli.config.Config.save")
+    updated = ConnectionConfig(name="test-env", url="https://other.example.com", api_key_cmd="echo key")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectionsScreen)
+            app.on_connections_screen_update_connection(
+                ConnectionsScreen.UpdateConnection(connection=updated, original=_connection())
+            )
+            await pilot.pause()
+            assert app.screen.connections[0].url.host == "other.example.com"
             save.assert_called_once()
 
     _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -3,11 +3,12 @@
 import asyncio
 
 import httpx
+from textual.command import CommandPalette
 from textual.containers import VerticalScroll
 from textual.widgets import Label
 
 from dokli.config import Config, ConnectionConfig
-from dokli.tui.app import DokliApp
+from dokli.tui.app import DokliApp, DokliCommands
 from dokli.tui.engine import build_form_model, clear_probe_cache, parse_spec, probe_entity, record_title
 from dokli.tui.engine.spec import Entity, EntityAction
 from dokli.tui.forms import Form, SelectControl, SwitchControl, TextAreaControl
@@ -15,6 +16,7 @@ from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.generic.browser import BrowserScreen, Level
 from dokli.tui.screens.generic.confirm import ConfirmScreen
 from dokli.tui.screens.generic.form import ActionFormScreen
+from dokli.tui.screens.generic.help import HelpScreen
 from dokli.tui.screens.generic.picker import PickerScreen
 from dokli.tui.screens.generic.result import ResultScreen
 from dokli.tui.screens.generic.wizard import WizardScreen
@@ -871,5 +873,123 @@ def test_connection_argument_unreachable_falls_back(mocker):
                 if isinstance(app.screen, ConnectionsScreen):
                     break
             assert isinstance(app.screen, ConnectionsScreen)
+
+    _run(main())
+
+
+# -- connections persistence ------------------------------------------------
+
+
+def test_add_connection_persists(mocker):
+    """We expect a new connection to be added to the config and saved."""
+    config = _config()
+    save = mocker.patch("dokli.config.Config.save")
+    new_connection = ConnectionConfig(name="stage", url="https://stage.example.com", api_key_cmd="echo key")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_connections_screen_add_connection(ConnectionsScreen.AddConnection(connection=new_connection))
+            assert any(c.name == "stage" for c in app.config.connections)
+            save.assert_called_once()
+
+    _run(main())
+
+
+def test_update_connection_persists(mocker):
+    """We expect an edited connection to replace the existing one and be saved."""
+    config = _config()
+    save = mocker.patch("dokli.config.Config.save")
+    updated = ConnectionConfig(name="test-env", url="https://other.example.com", api_key_cmd="echo key")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_connections_screen_update_connection(ConnectionsScreen.UpdateConnection(connection=updated))
+            assert app.config.connections[0].url.host == "other.example.com"
+            assert len(app.config.connections) == 1
+            save.assert_called_once()
+
+    _run(main())
+
+
+def test_delete_connection_persists(mocker):
+    """We expect a deleted connection to be removed from the config and saved."""
+    config = _config()
+    save = mocker.patch("dokli.config.Config.save")
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_connections_screen_delete_connection(ConnectionsScreen.DeleteConnection(connection=_connection()))
+            assert app.config.connections == []
+            save.assert_called_once()
+
+    _run(main())
+
+
+# -- help + command palette -------------------------------------------------
+
+
+def test_help_screen_shows_bindings(mocker):
+    """We expect ? to open the help screen listing the keybindings."""
+    _patch_api(mocker)
+
+    async def main():
+        app = DokliApp(config=_config(), connection=_connection())
+        async with app.run_test() as pilot:
+            for _ in range(30):
+                await pilot.pause()
+                if isinstance(app.screen, BrowserScreen):
+                    break
+            await pilot.press("?")
+            for _ in range(10):
+                await pilot.pause()
+                if isinstance(app.screen, HelpScreen):
+                    break
+            assert isinstance(app.screen, HelpScreen)
+            text = "\n".join(
+                str(label.renderable)
+                for label in app.screen.query_one("#help-scroll").children
+                if isinstance(label, Label)
+            )
+            assert "Quit" in text
+            assert "Connections" in text
+
+    _run(main())
+
+
+def test_command_palette_opens(mocker):
+    """We expect the command palette to open on ctrl+backslash."""
+    _patch_api(mocker)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+backslash")
+            await pilot.pause()
+            assert isinstance(app.screen, CommandPalette)
+
+    _run(main())
+
+
+def test_command_provider_lists_connections(mocker):
+    """We expect the command palette provider to offer connections and core commands."""
+    _patch_api(mocker)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            provider = DokliCommands(app.screen)
+            hits = [hit async for hit in provider.discover()]
+            names = [hit.text for hit in hits]
+            assert "Open test-env" in names
+            assert "Help" in names
+            assert "Quit" in names
 
     _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1177,6 +1177,36 @@ def test_connection_edit_syncs_screen(mocker):
     _run(main())
 
 
+def test_switch_connection_reuses_browser(mocker):
+    """We expect switching connections to reload the browser, not re-install it."""
+    _patch_api(mocker)
+
+    async def main():
+        app = DokliApp(config=_config(), connection=_connection())
+        async with app.run_test() as pilot:
+            for _ in range(30):
+                await pilot.pause()
+                if isinstance(app.screen, BrowserScreen):
+                    break
+            first = app.screen
+            # go back to the connections screen and pick another connection
+            app.action_connections()
+            for _ in range(10):
+                await pilot.pause()
+                if isinstance(app.screen, ConnectionsScreen):
+                    break
+            assert isinstance(app.screen, ConnectionsScreen)
+            second = ConnectionConfig(name="stage", url="https://stage.example.com", api_key_cmd="echo key")
+            app.set_connection(second)
+            for _ in range(20):
+                await pilot.pause()
+            assert isinstance(app.screen, BrowserScreen)
+            assert app.screen is first
+            assert app.screen.connection.name == "stage"
+
+    _run(main())
+
+
 # -- help + command palette -------------------------------------------------
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -46,6 +46,21 @@ FAKE_SCHEMA = {
             }
         },
         "/project.remove": {"post": {}},
+        "/project.update": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                                "required": ["name"],
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/environment.one": {"get": {"parameters": [{"name": "environmentId", "in": "query", "required": True}]}},
         "/compose.one": {"get": {"parameters": [{"name": "composeId", "in": "query", "required": True}]}},
         "/compose.update": {
@@ -1034,5 +1049,37 @@ def test_command_provider_lists_form_commands(mocker):
             names = [hit.text for hit in hits]
             assert "Submit form" in names
             assert "Wizard mode" in names
+
+    _run(main())
+
+
+def test_palette_runs_update_action(mocker):
+    """We expect an action chosen from the palette to run after the palette closes."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            _select(app, "project")
+            await pilot.pause()
+            await pilot.press("enter")
+            await _wait_for_label(app, pilot, "media")
+            await pilot.press("ctrl+p")
+            for _ in range(10):
+                await pilot.pause()
+            await pilot.press(*"run update")
+            for _ in range(15):
+                await pilot.pause()
+            await pilot.press("enter")
+            for _ in range(5):
+                await pilot.pause()
+            await pilot.press("enter")
+            for _ in range(30):
+                await pilot.pause()
+                if isinstance(app.screen, ActionFormScreen):
+                    break
+            assert isinstance(app.screen, ActionFormScreen)
 
     _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -993,3 +993,46 @@ def test_command_provider_lists_connections(mocker):
             assert "Quit" in names
 
     _run(main())
+
+
+def test_command_provider_lists_browser_actions(mocker):
+    """We expect the palette to expose the selected entity's available actions in the browser."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            _select(app, "project")
+            await pilot.pause()
+            provider = DokliCommands(app.screen)
+            hits = [hit async for hit in provider.discover()]
+            names = [hit.text for hit in hits]
+            assert "Run create on project" in names
+            assert "Run homeStats on project" in names
+            assert not any(name == "Run remove on project" for name in names)
+
+    _run(main())
+
+
+def test_command_provider_lists_form_commands(mocker):
+    """We expect the palette to expose form actions when a form is focused."""
+    mocker.patch("dokli.tui.app.APIClient")
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("project").get("create")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            screen = ActionFormScreen(_connection(), action)
+            app.install_screen(screen, name="form")
+            app.push_screen("form")
+            await pilot.pause()
+            provider = DokliCommands(app.screen)
+            hits = [hit async for hit in provider.discover()]
+            names = [hit.text for hit in hits]
+            assert "Submit form" in names
+            assert "Wizard mode" in names
+
+    _run(main())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -963,14 +963,14 @@ def test_help_screen_shows_bindings(mocker):
 
 
 def test_command_palette_opens(mocker):
-    """We expect the command palette to open on ctrl+backslash."""
+    """We expect the command palette to open on ctrl+p."""
     _patch_api(mocker)
 
     async def main():
         app = DokliApp(config=_config())
         async with app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("ctrl+backslash")
+            await pilot.press("ctrl+p")
             await pilot.pause()
             assert isinstance(app.screen, CommandPalette)
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1131,6 +1131,16 @@ def test_help_screen_shows_bindings(mocker):
     _run(main())
 
 
+def test_help_default_bindings_win_over_contextual():
+    """We expect default keybindings to win over contextual ones on collision."""
+    from dokli.tui.screens.generic.help import _merge_entries
+
+    default = [("c", "Copy"), ("r", "Refresh")]
+    contextual = [("r", "Run redeploy on app"), ("x", "Deploy")]
+    merged = _merge_entries(default, contextual)
+    assert merged == [("c", "Copy"), ("r", "Refresh"), ("x", "Deploy")]
+
+
 def test_command_palette_opens(mocker):
     """We expect the command palette to open on ctrl+p."""
     _patch_api(mocker)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -636,6 +636,117 @@ def test_query_action_shows_result(mocker):
     _run(main())
 
 
+def test_result_search_highlights_and_navigates(mocker):
+    """We expect / to open a search that counts matches and navigates with n/N."""
+    mocker.patch("dokli.tui.app.APIClient")
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("project").get("homeStats")
+    logs = "\n".join(f"2026-08-05 line {i} GET /api/projects" for i in range(5))
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            screen = ResultScreen(_connection(), action, logs)
+            app.install_screen(screen, name="result")
+            app.push_screen("result")
+            await pilot.pause()
+            await pilot.pause()
+            # no matches query
+            await pilot.press("/")
+            await pilot.pause()
+            await pilot.press(*"zzz")
+            await pilot.pause()
+            await pilot.pause()
+            assert str(screen.query_one("#match-status", Label).renderable) == "No matches"
+            await pilot.press("escape")
+            await pilot.pause()
+            await pilot.press("/")
+            await pilot.pause()
+            await pilot.press(*"api")
+            await pilot.pause()
+            await pilot.pause()
+            assert str(screen.query_one("#match-status", Label).renderable) == "1/5 matches"
+            # commit search (blur) then navigate
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.pause()
+            assert str(screen.query_one("#match-status", Label).renderable) == "2/5 matches"
+            await pilot.press("N")
+            await pilot.pause()
+            await pilot.pause()
+            assert str(screen.query_one("#match-status", Label).renderable) == "1/5 matches"
+
+    _run(main())
+
+
+def test_result_search_escape_clears(mocker):
+    """We expect escape to clear the search and restore the plain result."""
+    mocker.patch("dokli.tui.app.APIClient")
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("project").get("homeStats")
+    logs = "\n".join(f"2026-08-05 line {i} GET /api/projects" for i in range(3))
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            screen = ResultScreen(_connection(), action, logs)
+            app.install_screen(screen, name="result")
+            app.push_screen("result")
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("/")
+            await pilot.pause()
+            await pilot.press(*"api")
+            await pilot.pause()
+            await pilot.pause()
+            assert str(screen.query_one("#match-status", Label).renderable) == "1/3 matches"
+            await pilot.press("escape")
+            await pilot.pause()
+            await pilot.pause()
+            assert str(screen.query_one("#match-status", Label).renderable) == ""
+            assert isinstance(app.screen, ResultScreen)
+
+    _run(main())
+
+
+def test_result_refresh_refetches(mocker):
+    """We expect r to re-run the action with the original params and update the result."""
+    mocker.patch("dokli.tui.app.APIClient")
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("project").get("homeStats")
+    params = {"projectId": "p1"}
+
+    def fake_request(method, path, params_):
+        return FakeResponse({"projects": 99, "status": {"running": 1, "idle": 0}})
+
+    client = mocker.Mock()
+    client.request.side_effect = fake_request
+    mocker.patch("dokli.tui.screens.generic.result.APIClient", return_value=client)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            screen = ResultScreen(_connection(), action, {"projects": 0}, params=params)
+            app.install_screen(screen, name="result")
+            app.push_screen("result")
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("r")
+            await pilot.pause()
+            await pilot.pause()
+            client.request.assert_called_once_with("GET", action.route, params)
+            text = "\n".join(
+                str(label.renderable)
+                for label in screen.query_one("#result-scroll").children
+                if isinstance(label, Label)
+            )
+            assert "99" in text
+
+    _run(main())
+
+
 def test_read_logs_params_only_backfill_entity_id(mocker):
     """We expect GET params to backfill only the entity's own id, never other params."""
     _patch_api(mocker)
@@ -994,6 +1105,13 @@ def test_help_screen_shows_bindings(mocker):
                 await pilot.pause()
                 if isinstance(app.screen, BrowserScreen):
                     break
+            # select 'project' so its contextual actions are available
+            screen = app.screen
+            vis = screen._visible_items(screen.current)
+            screen.current.index = next(
+                i for i, item in enumerate(vis) if item.get("name") == "project"
+            )
+            await pilot.pause()
             await pilot.press("?")
             for _ in range(10):
                 await pilot.pause()
@@ -1007,6 +1125,8 @@ def test_help_screen_shows_bindings(mocker):
             )
             assert "Quit" in text
             assert "Connections" in text
+            # contextual action of the selected entity is listed
+            assert "create project" in text
 
     _run(main())
 

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -225,23 +225,23 @@ class TestIcons:
     def test_icon_label_wraps_in_color(self):
         """We expect icon_label to put the icon in a colored box."""
         label = icon_label("project")
-        assert "on yellow" in label
+        assert "on #f9e2af" in label
         assert "\uf07b" in label
         fallback = icon_label("totally_unknown")
-        assert "on grey70" in fallback
+        assert "on #6c7086" in fallback
 
     def test_state_color(self):
         """We expect a traffic-light color per container state."""
-        assert state_color("running") == "green"
-        assert state_color("paused") == "yellow"
-        assert state_color("restarting") == "yellow"
-        assert state_color("exited") == "red"
-        assert state_color("") == "grey70"
+        assert state_color("running") == "#a6e3a1"
+        assert state_color("paused") == "#f9e2af"
+        assert state_color("restarting") == "#f9e2af"
+        assert state_color("exited") == "#f38ba8"
+        assert state_color("") == "#6c7086"
 
     def test_state_indicator(self):
         """We expect a colored dot for the container state."""
-        assert state_indicator("running") == "[bold green]●[/]"
-        assert state_indicator("exited") == "[bold red]●[/]"
+        assert state_indicator("running") == "[bold #a6e3a1]●[/]"
+        assert state_indicator("exited") == "[bold #f38ba8]●[/]"
 
 
 class TestBuildFormModel:

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -18,6 +18,8 @@ from dokli.tui.engine import (
     parse_spec,
     record_id,
     record_title,
+    state_color,
+    state_indicator,
 )
 
 
@@ -25,9 +27,7 @@ def _spec() -> dict:
     return {
         "paths": {
             "/project.all": {"get": {"summary": "List projects"}},
-            "/project.one": {
-                "get": {"parameters": [{"name": "projectId", "in": "query", "required": True}]}
-            },
+            "/project.one": {"get": {"parameters": [{"name": "projectId", "in": "query", "required": True}]}},
             "/project.create": {
                 "post": {
                     "requestBody": {
@@ -230,6 +230,19 @@ class TestIcons:
         fallback = icon_label("totally_unknown")
         assert "on grey70" in fallback
 
+    def test_state_color(self):
+        """We expect a traffic-light color per container state."""
+        assert state_color("running") == "green"
+        assert state_color("paused") == "yellow"
+        assert state_color("restarting") == "yellow"
+        assert state_color("exited") == "red"
+        assert state_color("") == "grey70"
+
+    def test_state_indicator(self):
+        """We expect a colored dot for the container state."""
+        assert state_indicator("running") == "[bold green]●[/]"
+        assert state_indicator("exited") == "[bold red]●[/]"
+
 
 class TestBuildFormModel:
     """Schema → form model tests."""
@@ -254,16 +267,12 @@ class TestBuildFormModel:
 
     def test_enum_fields(self):
         """We expect string enums to be Literal."""
-        model = build_form_model(
-            {"properties": {"mode": {"type": "string", "enum": ["dev", "prod"]}}}
-        )
+        model = build_form_model({"properties": {"mode": {"type": "string", "enum": ["dev", "prod"]}}})
         assert model(mode="dev").mode == "dev"
 
     def test_anyof_annotation(self):
         """We expect anyOf null-unions to be unwrapped."""
-        model = build_form_model(
-            {"properties": {"autoDeploy": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}}}
-        )
+        model = build_form_model({"properties": {"autoDeploy": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}}})
         assert model(autoDeploy=True).autoDeploy is True
 
     def test_filters_read_only_fields(self):

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -11,6 +11,7 @@ from dokli.tui.engine import (
     classify,
     entity_icon,
     field_label,
+    icon_label,
     infer_columns,
     key_for_verb,
     nested_child_entity,
@@ -220,6 +221,14 @@ class TestIcons:
     def test_fallback_for_unknown(self):
         """We expect unknown entities to get a fallback icon."""
         assert entity_icon("totally_unknown") == "\uf15b"
+
+    def test_icon_label_wraps_in_color(self):
+        """We expect icon_label to put the icon in a colored box."""
+        label = icon_label("project")
+        assert "on yellow" in label
+        assert "\uf07b" in label
+        fallback = icon_label("totally_unknown")
+        assert "on grey70" in fallback
 
 
 class TestBuildFormModel:

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -185,6 +185,33 @@ class TestKeyBindings:
         assert by_verb["remove"] == "d"
         assert by_verb["restart"] == "R"
 
+    def test_read_logs_uses_uppercase_l(self):
+        """We expect readLogs to use L (uppercase), not the reserved drill-in l."""
+        assert key_for_verb("readLogs") == "L"
+        entity = self._entity("readLogs")
+        assert action_bindings(entity)[0][1] == "L"
+
+    def test_system_keys_are_not_assigned(self):
+        """We expect SYSTEM_KEYS (D) to never be assigned to an action."""
+        entity = self._entity(
+            "remove",
+            "redeploy",
+            "restart",
+            "search",
+            "start",
+            "save",
+            "suggest",
+            "sync",
+            "show",
+            "stop",
+            "status",
+            "submit",
+            "updateTeams",
+        )
+        bindings = action_bindings(entity)
+        keys = {key for _, key in bindings if key is not None}
+        assert "D" not in keys
+
     def test_fallback_to_free_key(self):
         """We expect a free key when all verb letters are taken."""
         assert key_for_verb("xyz", frozenset("xyzw")) == "a"

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -223,9 +223,10 @@ class TestIcons:
         assert entity_icon("totally_unknown") == "\uf15b"
 
     def test_icon_label_wraps_in_color(self):
-        """We expect icon_label to put the icon in a colored box."""
+        """We expect icon_label to put a dark icon in a colored box."""
         label = icon_label("project")
         assert "on #f9e2af" in label
+        assert "#1e1e2e" in label
         assert "\uf07b" in label
         fallback = icon_label("totally_unknown")
         assert "on #6c7086" in fallback


### PR DESCRIPTION
Part of #42 — Phase R3: connections persistence + Help + command palette, plus a batch of browser/result polish.

## What is in this PR

### R3 core
- **Connections persistence** (`config.py`, `app.py`, `screens/connections.py`):
  - `Config.save()` persists connections to the same YAML file that would be loaded (`./dokli.yaml` wins over `DOKLI_CONFIG`/default), unwrapping `api_key` secrets.
  - Add/update/delete handlers persist edits; the Connections screen list stays in sync; **renaming a connection replaces it** instead of duplicating.
- **Help screen** (`screens/generic/help.py`): `?` opens a keybinding reference (app + active screen + the selected entity's contextual actions). Default bindings win over contextual ones on collisions.
- **Command palette** (`app.py`): `ctrl+p` opens Textual's palette. `DokliCommands` offers core commands (toggle dark, connections, settings, help, quit), **per-connection "Open <name>"**, and **context-aware commands** for the focused screen — the browser exposes the selected entity's actions, forms expose submit/wizard/cancel. Each command's help line shows its shortcut.

### Browser
- 3 columns with **2:2:4 proportions** (parent : current : detail).
- Detail pane: record **name highlighted in the header**, no more "Actions" section (the palette covers actions); related containers show a **traffic-light dot** by state (`● name (running)`).
- Icons in record lists; entity icons rendered as **Catppuccin-colored boxes** with a dark glyph for contrast.
- **Container correlation fixed**: containers are found by the docker project name (`compose.one.appName` slug) + `appType`, enriching list records via `one` — `torrents` now shows its containers.

### Result screen
- **Search** (`/`): highlights matches, `N/M` counter, `n`/`N` navigate, enter commits, escape clears.
- **Refresh** (`F5`): re-runs the action with the original params (record-scoped GETs keep their id).

### Forms / misc
- Form/wizard/confirm action buttons laid out in a full-width horizontal bar.

### Keybindings & collisions
- Dark mode → `D` (was shadowed by contextual `d` delete); refresh → `F5`; `readLogs` → `L` (uppercase, was colliding with drill-in `l`).
- `SYSTEM_KEYS` in the engine: app-level keys are never assigned to contextual actions.

### Theme
- **Catppuccin** (Mocha dark / Latte light) palette for the theme, entity icons and state indicators.

## Verified

- Against `dokploy.meche.lan`: `torrents` shows 4 containers, `compose.readLogs` works via the container picker, help/palette list contextual actions, column proportions 2:2:4.
- `make lint` ✓, `make test` → 145 passed ✓.
