### PR TITLE
Store secrets in the OS keychain via keyring (CLI + TUI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Configuration uses [pydantic-settings](https://docs.pydantic.dev/latest/concepts
 
 You can also manage connections with `dokli connections ls|add|update|remove|get|test`, or from the TUI.
 
+### Secrets in the system keychain
+
+API keys, git provider credentials and database passwords can be stored in your OS keychain instead of the YAML files:
+
+- `dokli secrets set|get|rm <account>` — manage keychain entries (accounts like `conn.meche`, `provider.github-main`, `db.backend`); `get` masks by default, `--show` prints in plain text.
+- `dokli connections add <name> --keyring` / `dokli connections update <name> --keyring` — store the API key in the keychain (`api_key_keyring: true`) so it never touches the config file.
+- In manifests, `token_keyring: true` (git providers) and `password_keyring: true` (databases) resolve those secrets from the keychain at apply time.
+- Resolution order is: literal value → keychain → `*_cmd`.
+
+Uses the cross-platform [`keyring`](https://pypi.org/project/keyring/) package (SecretService / macOS Keychain / Windows Credential Locker).
+
 ## CLI
 
 ### Features

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -15,6 +15,7 @@ from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.diff import resolve_compose_file
 from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Service
+from dokli.secrets import db_account, get_secret
 from dokli.state import LiveGitProvider, LiveProject, LiveService, State, collect_state
 
 
@@ -326,8 +327,6 @@ class Applier:
         if service_def.password:
             return service_def.password
         if service_def.password_keyring:
-            from dokli.secrets import db_account, get_secret
-
             value = get_secret(db_account(service_def.name))
             if value:
                 return value

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -325,6 +325,12 @@ class Applier:
         """Resolve a database password from the manifest (or generate one)."""
         if service_def.password:
             return service_def.password
+        if service_def.password_keyring:
+            from dokli.secrets import db_account, get_secret
+
+            value = get_secret(db_account(service_def.name))
+            if value:
+                return value
         if service_def.password_cmd:
             output = subprocess.check_output(service_def.password_cmd, shell=True)
             return output.decode("utf-8").strip()
@@ -434,7 +440,7 @@ class Applier:
             database_user = service_def.database_user or service_def.name
             if live is None or live.database_user != database_user:
                 payload["databaseUser"] = database_user
-        if service_def.password or service_def.password_cmd:
+        if service_def.password or service_def.password_keyring or service_def.password_cmd:
             password = self._resolve_database_password(service_def)
             if live is None or live.database_password != password:
                 payload["databasePassword"] = password

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -17,6 +17,7 @@ from dokli.formatting import redact_secrets
 from dokli.init import init_manifest
 from dokli.manifest import Manifest
 from dokli.openapi_cli import build_command as build_api_command
+from dokli.secrets_cli import build_command as build_secrets_command
 from dokli.state import collect_state
 
 try:
@@ -32,6 +33,7 @@ state: dict[str, Any] = {
 }
 app.add_typer(build_api_command(state["config"]))
 app.add_typer(build_connections_command(state["config"]))
+app.add_typer(build_secrets_command())
 
 
 def tui_command(connection_name: str | None = typer.Argument(None, help="Connection name.")) -> None:

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -10,6 +10,8 @@ import yaml
 from pydantic import BaseModel, Field, HttpUrl, SecretStr, field_serializer, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, YamlConfigSettingsSource
 
+from dokli.secrets import conn_account, get_secret
+
 
 class ConnectionConfig(BaseModel):
     """Connection config."""
@@ -59,8 +61,6 @@ class ConnectionConfig(BaseModel):
         if self.api_key is not None:
             return self.api_key.get_secret_value()
         if self.api_key_keyring:
-            from dokli.secrets import conn_account, get_secret
-
             value = get_secret(conn_account(self.name))
             if value:
                 return value

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -29,6 +29,9 @@ class ConnectionConfig(BaseModel):
         description="An API key for the dokploy instance.",
     )
     api_key_cmd: str | None = Field(None, description="A command to get the API key.")
+    api_key_keyring: bool = Field(
+        False, description="Store the API key in the system keychain instead of the config file."
+    )
     notes: str = Field(default="", description="Notes about the connection.")
 
     @field_serializer("api_key", when_used="json")
@@ -42,16 +45,26 @@ class ConnectionConfig(BaseModel):
 
     @model_validator(mode="after")
     def check_api_key_or_cmd(self) -> "ConnectionConfig":
-        """Validate api_key or api_key_cmd is provided."""
-        if not self.api_key and not self.api_key_cmd:
-            raise ValueError("Must provide api_key or api_key_cmd.")
+        """Validate api_key, api_key_keyring or api_key_cmd is provided."""
+        if not self.api_key and not self.api_key_keyring and not self.api_key_cmd:
+            raise ValueError("Must provide api_key, api_key_keyring or api_key_cmd.")
         return self
 
     def get_api_key(self) -> str:
-        """Returns the API key for the connection."""
+        """Returns the API key for the connection.
+
+        Resolution order: literal ``api_key``, then the system keychain
+        (``api_key_keyring``), then ``api_key_cmd``.
+        """
         if self.api_key is not None:
             return self.api_key.get_secret_value()
-        assert self.api_key_cmd, "Must provide api_key or api_key_cmd."
+        if self.api_key_keyring:
+            from dokli.secrets import conn_account, get_secret
+
+            value = get_secret(conn_account(self.name))
+            if value:
+                return value
+        assert self.api_key_cmd, "Must provide api_key, api_key_keyring or api_key_cmd."
         raw_output = subprocess.check_output(self.api_key_cmd, shell=True)
         output = raw_output.decode("utf-8").strip().strip("\n")
         return output

--- a/dokli/connections.py
+++ b/dokli/connections.py
@@ -9,6 +9,7 @@ from rich.table import Table
 from dokli.api_client import APIClient
 from dokli.config import Config, ConnectionConfig
 from dokli.formatting import redact_secrets
+from dokli.secrets import conn_account, set_secret
 
 
 def build_command(config: Config) -> typer.Typer:
@@ -26,10 +27,13 @@ def build_command(config: Config) -> typer.Typer:
         url: str | None = typer.Option(None, "--url", help="Dokploy instance URL."),
         api_key: str | None = typer.Option(None, "--api-key", help="API key (64 chars)."),
         api_key_cmd: str | None = typer.Option(None, "--api-key-cmd", help="Command that outputs the API key."),
+        keyring: bool = typer.Option(
+            False, "--keyring", help="Store the API key in the system keychain instead of the config file."
+        ),
         notes: str | None = typer.Option(None, "--notes", help="Notes about the connection."),
     ) -> None:
         """Add a connection (missing values are prompted)."""
-        _add_connection(config, name, url, api_key, api_key_cmd, notes)
+        _add_connection(config, name, url, api_key, api_key_cmd, keyring, notes)
 
     @group.command("update")
     def update_connection(
@@ -38,10 +42,13 @@ def build_command(config: Config) -> typer.Typer:
         url: str | None = typer.Option(None, "--url", help="New URL."),
         api_key: str | None = typer.Option(None, "--api-key", help="New API key (64 chars)."),
         api_key_cmd: str | None = typer.Option(None, "--api-key-cmd", help="New command that outputs the API key."),
+        keyring: bool = typer.Option(
+            False, "--keyring", help="Move the API key to the system keychain."
+        ),
         notes: str | None = typer.Option(None, "--notes", help="New notes."),
     ) -> None:
         """Update a connection (optionally renaming it)."""
-        _update_connection(config, name, new_name, url, api_key, api_key_cmd, notes)
+        _update_connection(config, name, new_name, url, api_key, api_key_cmd, keyring, notes)
 
     @group.command("remove")
     def remove_connection(name: str = typer.Argument(..., help="Connection name.")) -> None:
@@ -94,6 +101,7 @@ def _add_connection(
     url: str | None,
     api_key: str | None,
     api_key_cmd: str | None,
+    keyring: bool,
     notes: str | None,
 ) -> None:
     if not name:
@@ -102,12 +110,24 @@ def _add_connection(
         raise typer.BadParameter(f"Connection '{name}' already exists.")
     if not url:
         url = typer.prompt("URL")
-    if not api_key and not api_key_cmd:
-        api_key = typer.prompt("API key", hide_input=True)
+    if keyring:
+        if not api_key:
+            api_key = typer.prompt("API key", hide_input=True)
+        set_secret(conn_account(name), api_key)
+        data = {
+            "name": name,
+            "url": url,
+            "api_key": None,
+            "api_key_cmd": None,
+            "api_key_keyring": True,
+            "notes": notes or "",
+        }
+    else:
+        if not api_key and not api_key_cmd:
+            api_key = typer.prompt("API key", hide_input=True)
+        data = {"name": name, "url": url, "api_key": api_key, "api_key_cmd": api_key_cmd, "notes": notes or ""}
     try:
-        connection = ConnectionConfig.model_validate(
-            {"name": name, "url": url, "api_key": api_key, "api_key_cmd": api_key_cmd, "notes": notes or ""}
-        )
+        connection = ConnectionConfig.model_validate(data)
     except ValidationError as err:
         raise typer.BadParameter(err.errors()[0]["msg"]) from None
     config.connections = [*config.connections, connection]
@@ -122,11 +142,18 @@ def _update_connection(
     url: str | None,
     api_key: str | None,
     api_key_cmd: str | None,
+    keyring: bool,
     notes: str | None,
 ) -> None:
     current = _find(config, name)
     renaming = new_name is not None and new_name != name
-    has_fields = url is not None or api_key is not None or api_key_cmd is not None or notes is not None
+    has_fields = (
+        url is not None
+        or api_key is not None
+        or api_key_cmd is not None
+        or keyring
+        or notes is not None
+    )
     if new_name is not None and not renaming and has_fields:
         rprint(f"[yellow]'{name}' is already named '{new_name}' (rename skipped).[/yellow]")
     if not renaming and not has_fields:
@@ -139,12 +166,19 @@ def _update_connection(
         data["name"] = new_name
     if url is not None:
         data["url"] = url
-    if api_key is not None:
+    if keyring:
+        set_secret(conn_account(name), current.get_api_key())
+        data["api_key"] = None
+        data["api_key_cmd"] = None
+        data["api_key_keyring"] = True
+    elif api_key is not None:
         data["api_key"] = api_key
         data["api_key_cmd"] = None
+        data["api_key_keyring"] = False
     elif api_key_cmd is not None:
         data["api_key_cmd"] = api_key_cmd
         data["api_key"] = None
+        data["api_key_keyring"] = False
     if notes is not None:
         data["notes"] = notes
     try:

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -30,6 +30,10 @@ class GitProvider(BaseModel):
         default=None,
         description="Command that outputs the credential. Never store the value here.",
     )
+    token_keyring: bool = Field(
+        default=False,
+        description="Store the credential in the system keychain (provider.<name>).",
+    )
 
 
 class GitSource(BaseModel):
@@ -95,6 +99,10 @@ class DatabaseService(BaseModel):
     password_cmd: str | None = Field(
         default=None,
         description="Command that outputs the database password. Resolved at apply time.",
+    )
+    password_keyring: bool = Field(
+        default=False,
+        description="Store the database password in the system keychain (db.<name>).",
     )
     env: str | None = Field(default=None, description="Environment variables as KEY=VALUE lines.")
 

--- a/dokli/secrets.py
+++ b/dokli/secrets.py
@@ -1,0 +1,50 @@
+"""Secrets stored in the OS keychain via :mod:`keyring`.
+
+Deterministic account names (service ``dokli``):
+
+- ``conn.<name>`` — API key of a connection.
+- ``provider.<name>`` — git provider credential.
+- ``db.<name>`` — database password.
+
+Resolution order used by the models is: literal value in the config/manifest,
+then the keychain, then ``*_cmd``. Storing a secret in the keychain keeps it
+out of the YAML files.
+"""
+
+import contextlib
+
+import keyring
+from keyring import errors
+
+SERVICE = "dokli"
+
+
+def set_secret(account: str, value: str) -> None:
+    """Store a secret under an account name."""
+    keyring.set_password(SERVICE, account, value)
+
+
+def get_secret(account: str) -> str | None:
+    """Return a stored secret, or ``None`` if it does not exist."""
+    return keyring.get_password(SERVICE, account)
+
+
+def delete_secret(account: str) -> None:
+    """Remove a stored secret, ignoring missing accounts."""
+    with contextlib.suppress(errors.PasswordDeleteError):
+        keyring.delete_password(SERVICE, account)
+
+
+def conn_account(name: str) -> str:
+    """Keychain account for a connection's API key."""
+    return f"conn.{name}"
+
+
+def provider_account(name: str) -> str:
+    """Keychain account for a git provider's credential."""
+    return f"provider.{name}"
+
+
+def db_account(name: str) -> str:
+    """Keychain account for a database service's password."""
+    return f"db.{name}"

--- a/dokli/secrets_cli.py
+++ b/dokli/secrets_cli.py
@@ -1,0 +1,77 @@
+"""CLI commands to manage secrets in the system keychain (issue #48)."""
+
+import sys
+
+import typer
+from rich import print as rprint
+from rich.table import Table
+
+from dokli.secrets import SERVICE, delete_secret, get_secret, set_secret
+
+
+def build_command() -> typer.Typer:
+    """Build the ``dokli secrets`` command group."""
+    group = typer.Typer(name="secrets", help="Manage secrets in the system keychain.", no_args_is_help=True)
+
+    @group.command("set")
+    def set_secret_cmd(
+        account: str = typer.Argument(..., help="Account name, e.g. conn.meche."),
+        stdin: bool = typer.Option(False, "--stdin", help="Read the value from stdin instead of prompting."),
+    ) -> None:
+        """Store a secret (value is prompted hidden, or read from stdin)."""
+        value = _read_secret(stdin)
+        if not value:
+            raise typer.BadParameter("Empty value.")
+        set_secret(account, value)
+        rprint(f"[green]Stored secret '{account}'.[/green]")
+
+    @group.command("get")
+    def get_secret_cmd(
+        account: str = typer.Argument(..., help="Account name, e.g. conn.meche."),
+        show: bool = typer.Option(False, "--show", help="Print the value in plain text."),
+    ) -> None:
+        """Show a stored secret (masked by default)."""
+        value = get_secret(account)
+        if value is None:
+            rprint(f"[red]No secret stored for '{account}'.[/red]")
+            raise typer.Exit(code=1)
+        rprint(value if show else _mask(value))
+
+    @group.command("rm")
+    def remove_secret_cmd(account: str = typer.Argument(..., help="Account name, e.g. conn.meche.")) -> None:
+        """Remove a stored secret."""
+        delete_secret(account)
+        rprint(f"[green]Removed secret '{account}'.[/green]")
+
+    @group.command("ls")
+    def list_secrets_cmd() -> None:
+        """List stored secrets (best effort; not all keyring backends support it)."""
+        import keyring
+
+        backend = keyring.get_keyring()
+        list_method = getattr(backend, "list", None)
+        if list_method is None:
+            rprint("[yellow]Listing is not supported by this keyring backend.[/yellow]")
+            return
+        table = Table(title="Secrets")
+        table.add_column("Account")
+        for service, account in list_method():
+            if service == SERVICE:
+                table.add_row(account)
+        rprint(table)
+
+    return group
+
+
+def _read_secret(stdin: bool) -> str:
+    """Read a secret value from stdin or a hidden prompt."""
+    if stdin:
+        return sys.stdin.readline().strip("\n")
+    return typer.prompt("Value", hide_input=True)
+
+
+def _mask(value: str) -> str:
+    """Mask a secret value, showing only the first and last four characters."""
+    if len(value) <= 8:
+        return "***"
+    return f"{value[:4]}…{value[-4:]}"

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -266,6 +266,11 @@ class DokliApp(App):
         When ``original`` is given (edit with a possible rename), the entry is
         replaced by the original's identity so a rename does not duplicate it.
         """
+        if connection.api_key_keyring and connection.api_key is not None:
+            from dokli.secrets import conn_account, set_secret
+
+            set_secret(conn_account(connection.name), connection.api_key.get_secret_value())
+            connection = connection.model_copy(update={"api_key": None})
         names = [existing.name for existing in self.config.connections]
         if original is not None and original.name in names:
             target = original.name

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -14,6 +14,7 @@ from textual.widgets import Footer, Header, Static
 
 from dokli.api_client import APIClient
 from dokli.config import Config, ConnectionConfig
+from dokli.secrets import conn_account, set_secret
 from dokli.tui.engine import parse_spec, record_title
 from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.generic.browser import BrowserScreen
@@ -267,8 +268,6 @@ class DokliApp(App):
         replaced by the original's identity so a rename does not duplicate it.
         """
         if connection.api_key_keyring and connection.api_key is not None:
-            from dokli.secrets import conn_account, set_secret
-
             set_secret(conn_account(connection.name), connection.api_key.get_secret_value())
             connection = connection.model_copy(update={"api_key": None})
         names = [existing.name for existing in self.config.connections]

--- a/dokli/tui/forms.py
+++ b/dokli/tui/forms.py
@@ -15,6 +15,7 @@ from textual.widgets import Input, Label, Select, Static, Switch, TextArea
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
+    from textual.timer import Timer
 
 
 M = TypeVar("M", bound=BaseModel)
@@ -28,6 +29,28 @@ def _core_annotation(annotation: Any) -> Any:
         if len(non_none) == 1:
             return non_none[0]
     return annotation
+
+
+def _is_optional(annotation: Any) -> bool:
+    """Whether an annotation allows ``None``."""
+    origin = get_origin(annotation)
+    return (origin is Union or origin is UnionType) and NoneType in get_args(annotation)
+
+
+def _apply_field_defaults(model: type[BaseModel], data: dict[str, Any]) -> dict[str, Any]:
+    """Replace ``None`` with the field default for non-optional fields.
+
+    Empty inputs yield ``None`` from ``get_data``; a non-optional field (e.g.
+    ``notes: str = ""``) must fall back to its default instead of failing
+    validation.
+    """
+    resolved = dict(data)
+    for name, field in model.model_fields.items():
+        if name in resolved and resolved[name] is None and not _is_optional(field.annotation):
+            default = field.get_default(call_default_factory=True)
+            if default is not None:
+                resolved[name] = default
+    return resolved
 
 
 class FormControl(Static):
@@ -294,6 +317,7 @@ class Form(Generic[M], Container):
         self.model = model if not instance else type(instance)
         self.cleaned_data = None
         self.validate_on_input = validate_on_input
+        self._validate_timer: Timer | None = None
 
     async def on_mount(self) -> None:
         """On mount, add the form-level error label."""
@@ -334,8 +358,17 @@ class Form(Generic[M], Container):
         return {} if instance is None else json.loads(instance.model_dump_json())
 
     def _validate_on_input(self) -> None:
-        if self.validate_on_input:
-            self.validate()
+        """Debounce live validation so rapid typing/backspace does not stall."""
+        if not self.validate_on_input:
+            return
+        if self._validate_timer is not None:
+            self._validate_timer.stop()
+        self._validate_timer = self.set_timer(0.15, self._validate_now)
+
+    def _validate_now(self) -> None:
+        """Run a deferred validation (from the debounce timer)."""
+        self._validate_timer = None
+        self.validate()
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """On input changed."""
@@ -362,7 +395,7 @@ class Form(Generic[M], Container):
             self.cleaned_data = data
             return True
         try:
-            self.instance = self.model.model_validate(data)
+            self.instance = self.model.model_validate(_apply_field_defaults(self.model, data))
             self.cleaned_data = self.instance.model_dump()
             self.post_message(self.FormValid(data=self.cleaned_data or {}, instance=self.instance))
             return True

--- a/dokli/tui/screens/connection.py
+++ b/dokli/tui/screens/connection.py
@@ -10,7 +10,7 @@ from textual.containers import Horizontal
 from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import ModalScreen
-from textual.widgets import Button, Footer, Header, Input, Rule
+from textual.widgets import Button, Footer, Header, Input, Rule, Switch
 
 from dokli.config import ConnectionConfig
 from dokli.tui.forms import Form
@@ -52,7 +52,10 @@ class ConnectionScreen(ModalScreen[ConnectionResult]):
         """Create child widgets for the app."""
         yield Header()
         yield Footer()
-        yield Form.from_model(ConnectionConfig, self.connection)
+        # New connections default to the keychain (secure by default); editing
+        # an existing connection keeps its stored value.
+        form_data = None if self.connection else {"api_key_keyring": True}
+        yield Form.from_model(ConnectionConfig, self.connection, data=form_data)
         yield Rule()
         yield Horizontal(
             Button("Save", variant="success", id="save"),
@@ -73,6 +76,20 @@ class ConnectionScreen(ModalScreen[ConnectionResult]):
         """Watch connection changes."""
         self.app.sub_title = "New Connection" if not new_value else f"Edit Connection: {new_value.name}"
         log("ConnectionScreen", self.connection)
+
+    def on_switch_changed(self, event: Switch.Changed) -> None:
+        """When the keychain toggle changes, hide/reset the api_key_cmd field."""
+        if event.switch.id == "api_key_keyring-input":
+            self._sync_keyring_fields()
+
+    def _sync_keyring_fields(self) -> None:
+        """Hide api_key_cmd when the keychain is active, and reset its value."""
+        form = self.query_one(Form)
+        keyring = bool(form.fields["api_key_keyring"].value)
+        api_key_cmd = form.fields["api_key_cmd"]
+        api_key_cmd.display = not keyring
+        if keyring:
+            api_key_cmd.value = None
 
     def action_save(self) -> None:
         """Save connection."""
@@ -99,6 +116,7 @@ class ConnectionScreen(ModalScreen[ConnectionResult]):
     def on_screen_resume(self, event: events.ScreenResume) -> None:
         """On screen resume."""
         log("on screen resume", self.connection)
+        self._sync_keyring_fields()
         if self.focus_on_resume:
             with contextlib.suppress(NoMatches):
                 self.query(Input).first().focus()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
     "pydantic-settings[yaml]>=2.4.0,<3.0.0",
     "humanize>=4.10.0,<5.0.0",
     "httpx>=0.28.1,<0.29.0",
+    "keyring>=25.7.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures."""
+
+import keyring.core
+import pytest
+from keyring.backend import KeyringBackend
+
+
+class FakeKeyring(KeyringBackend):
+    """In-memory keyring backend for tests."""
+
+    priority = 10
+
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.store[(service, username)] = password
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        self.store.pop((service, username), None)
+
+
+@pytest.fixture()
+def fake_keyring(monkeypatch):
+    """Point keyring at an in-memory backend."""
+    fake = FakeKeyring()
+    monkeypatch.setattr(keyring.core, "_keyring_backend", fake)
+    return fake

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,6 +93,14 @@ class TestConnectionConfig:
         assert config.get_api_key() == "my api key from cmd"
         check_output.assert_called_once_with(config.api_key_cmd, shell=True)
 
+    def test_get_api_key_prefers_keyring(self, fake_keyring):
+        """We expect the keychain to be used before api_key_cmd."""
+        fake_keyring.store[("dokli", "conn.meche")] = "*" * 64
+        config = ConnectionConfigFactory.build(
+            name="meche", api_key=None, api_key_keyring=True, api_key_cmd="echo key"
+        )
+        assert config.get_api_key() == "*" * 64
+
     def test_api_key_cmd_supports_pipes(self, mocker):
         """We expect the API key command to run through a shell (pipes work)."""
         config = ConnectionConfigFactory.build(api_key_cmd="printf secret | tr a-z A-Z")

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -49,6 +49,32 @@ def test_add_connection_persists(tmp_path, monkeypatch):
     assert saved["connections"][0]["name"] == "stage"
 
 
+def test_add_connection_with_keyring(tmp_path, monkeypatch, fake_keyring):
+    """We expect --keyring to store the key in the keychain, not the config."""
+    config = _config(tmp_path, monkeypatch)
+    result = runner.invoke(
+        _app(config),
+        ["connections", "add", "stage", "--url", "https://stage.example.com", "--api-key", "*" * 64, "--keyring"],
+    )
+    assert result.exit_code == 0
+    connection = config.connections[0]
+    assert connection.api_key is None
+    assert connection.api_key_keyring is True
+    assert fake_keyring.store[("dokli", "conn.stage")] == "*" * 64
+    assert "*" * 64 not in (tmp_path / "dokli.yaml").read_text()
+
+
+def test_update_connection_with_keyring(tmp_path, monkeypatch, fake_keyring):
+    """We expect --keyring on update to move the key to the keychain."""
+    config = _config(tmp_path, monkeypatch, connections=[_conn()])
+    result = runner.invoke(_app(config), ["connections", "update", "meche", "--keyring"])
+    assert result.exit_code == 0
+    updated = config.connections[0]
+    assert updated.api_key is None
+    assert updated.api_key_keyring is True
+    assert fake_keyring.store[("dokli", "conn.meche")] == "*" * 64
+
+
 def test_add_prompts_for_missing_name_and_url(tmp_path, monkeypatch):
     """We expect add to prompt for name and url when not provided."""
     config = _config(tmp_path, monkeypatch)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,72 @@
+"""Keychain secrets tests (issue #48)."""
+
+import typer
+from typer.testing import CliRunner
+
+from dokli.secrets import SERVICE, conn_account, db_account, delete_secret, get_secret, provider_account, set_secret
+from dokli.secrets_cli import _mask, build_command
+
+runner = CliRunner()
+
+
+def _app():
+    app = typer.Typer()
+    app.add_typer(build_command())
+    return app
+
+
+class TestSecrets:
+    """Keychain wrapper tests."""
+
+    def test_set_get_delete(self, fake_keyring):
+        """We expect a secret to round-trip through the keychain."""
+        set_secret(conn_account("meche"), "*" * 64)
+        assert get_secret(conn_account("meche")) == "*" * 64
+        delete_secret(conn_account("meche"))
+        assert get_secret(conn_account("meche")) is None
+
+    def test_delete_missing_is_noop(self, fake_keyring):
+        """We expect deleting an absent secret not to raise."""
+        delete_secret(conn_account("nope"))
+
+    def test_account_names(self):
+        """We expect deterministic account names."""
+        assert conn_account("meche") == "conn.meche"
+        assert provider_account("github-main") == "provider.github-main"
+        assert db_account("backend") == "db.backend"
+
+
+class TestSecretsCLI:
+    """dokli secrets command tests."""
+
+    def test_set_get_rm(self, fake_keyring):
+        """We expect the CLI to store, read and remove a secret."""
+        result = runner.invoke(
+            _app(), ["secrets", "set", "conn.meche", "--stdin"], input="*" * 64 + "\n"
+        )
+        assert result.exit_code == 0
+        assert fake_keyring.store[("dokli", "conn.meche")] == "*" * 64
+
+        result = runner.invoke(_app(), ["secrets", "get", "conn.meche"])
+        assert result.exit_code == 0
+        assert "*" * 64 not in result.output
+        assert "***" in result.output or "…" in result.output
+
+        result = runner.invoke(_app(), ["secrets", "get", "conn.meche", "--show"])
+        assert result.exit_code == 0
+        assert "*" * 64 in result.output
+
+        result = runner.invoke(_app(), ["secrets", "rm", "conn.meche"])
+        assert result.exit_code == 0
+        assert ("dokli", "conn.meche") not in fake_keyring.store
+
+    def test_get_missing_fails(self, fake_keyring):
+        """We expect get on an absent secret to fail with a non-zero exit."""
+        result = runner.invoke(_app(), ["secrets", "get", "conn.nope"])
+        assert result.exit_code == 1
+
+
+def test_mask():
+    """We expect the value to be masked, keeping only the edges."""
+    assert _mask("*" * 64) == "****…****"
+    assert _mask("short") == "***"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -5,7 +5,7 @@ import asyncio
 import httpx
 from textual.command import CommandPalette
 from textual.containers import VerticalScroll
-from textual.widgets import Label
+from textual.widgets import Input, Label, Switch
 
 from dokli.config import Config, ConnectionConfig
 from dokli.tui.app import DokliApp, DokliCommands
@@ -268,12 +268,103 @@ def test_connection_form_model_error_no_crash(mocker):
             form.fields["name"].value = "hot-test"
             form.fields["url"].value = "https://storm.example.dev"
             form.fields["notes"].value = "H"
+            # keychain is on by default for new connections; turn it off so the
+            # form has no credential and the model-level error is exercised.
+            form.fields["api_key_keyring"].value = False
             form.validate()
             assert form.error == "Must provide api_key, api_key_keyring or api_key_cmd."
             # typing in notes triggers validation without crashing
             form.fields["notes"].value = "HELLO"
             form.validate()
             assert form.error == "Must provide api_key, api_key_keyring or api_key_cmd."
+
+    _run(main())
+
+
+def test_connection_form_notes_optional(mocker):
+    """We expect an empty notes field not to make the connection form invalid."""
+    mocker.patch("dokli.config.Config.save")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.action_add_connection()
+            for _ in range(10):
+                await pilot.pause()
+            form = app.screen.query_one(Form)
+            form.fields["name"].value = "hot-test"
+            form.fields["url"].value = "https://storm.example.dev"
+            form.fields["api_key"].value = "*" * 64
+            assert form.validate() is True
+            assert form.cleaned_data["notes"] == ""
+
+    _run(main())
+
+
+def test_connection_form_keyring_default_on_for_new(mocker):
+    """We expect new connection forms to default to the keychain (secure by default)."""
+    mocker.patch("dokli.config.Config.save")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.action_add_connection()
+            for _ in range(10):
+                await pilot.pause()
+            form = app.screen.query_one(Form)
+            assert form.fields["api_key_keyring"].value is True
+            assert form.fields["api_key_cmd"].display is False
+
+    _run(main())
+
+
+def test_connection_form_keyring_toggle_shows_api_key_cmd(mocker):
+    """We expect toggling the keychain to hide/show the api_key_cmd field."""
+    mocker.patch("dokli.config.Config.save")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.action_add_connection()
+            for _ in range(10):
+                await pilot.pause()
+            form = app.screen.query_one(Form)
+            api_key_cmd = form.fields["api_key_cmd"]
+            assert api_key_cmd.display is False  # keyring default on for new
+            keyring_switch = form.fields["api_key_keyring"].query_one(Switch)
+            keyring_switch.value = False
+            await pilot.pause()
+            assert api_key_cmd.display is True
+            keyring_switch.value = True
+            await pilot.pause()
+            assert api_key_cmd.display is False
+            assert api_key_cmd.value is None
+
+    _run(main())
+
+
+def test_form_validation_is_debounced(mocker):
+    """We expect live validation to be debounced so rapid typing does not stall."""
+    mocker.patch("dokli.config.Config.save")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.action_add_connection()
+            for _ in range(10):
+                await pilot.pause()
+            form = app.screen.query_one(Form)
+            form.fields["name"].query_one(Input).focus()
+            await pilot.pause()
+            await pilot.press("x")
+            await pilot.pause(0.05)
+            assert form._validate_timer is not None
+            await pilot.pause(0.25)
+            assert form._validate_timer is None
 
     _run(main())
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -242,13 +242,13 @@ def test_form_surfaces_model_level_errors():
         [
             {
                 "loc": (),
-                "msg": "Must provide api_key or api_key_cmd.",
+                "msg": "Must provide api_key, api_key_keyring or api_key_cmd.",
                 "type": "value_error",
                 "input": {"name": "hot-test", "api_key": None, "api_key_cmd": None},
             }
         ]
     )
-    assert form.error == "Must provide api_key or api_key_cmd."
+    assert form.error == "Must provide api_key, api_key_keyring or api_key_cmd."
 
 
 def test_connection_form_model_error_no_crash(mocker):
@@ -269,11 +269,11 @@ def test_connection_form_model_error_no_crash(mocker):
             form.fields["url"].value = "https://storm.example.dev"
             form.fields["notes"].value = "H"
             form.validate()
-            assert form.error == "Must provide api_key or api_key_cmd."
+            assert form.error == "Must provide api_key, api_key_keyring or api_key_cmd."
             # typing in notes triggers validation without crashing
             form.fields["notes"].value = "HELLO"
             form.validate()
-            assert form.error == "Must provide api_key or api_key_cmd."
+            assert form.error == "Must provide api_key, api_key_keyring or api_key_cmd."
 
     _run(main())
 
@@ -1098,6 +1098,26 @@ def test_add_connection_persists(mocker):
             await pilot.pause()
             app.on_connections_screen_add_connection(ConnectionsScreen.AddConnection(connection=new_connection))
             assert any(c.name == "stage" for c in app.config.connections)
+            save.assert_called_once()
+
+    _run(main())
+
+
+def test_save_connection_with_keyring_stores_key(mocker, fake_keyring):
+    """We expect saving a connection with the keychain toggle to store the key there."""
+    config = _config()
+    save = mocker.patch("dokli.config.Config.save")
+    connection = ConnectionConfig(name="stage", url="https://stage.example.com", api_key="*" * 64, api_key_keyring=True)
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_connections_screen_add_connection(ConnectionsScreen.AddConnection(connection=connection))
+            assert fake_keyring.store[("dokli", "conn.stage")] == "*" * 64
+            saved = next(c for c in app.config.connections if c.name == "stage")
+            assert saved.api_key is None
+            assert saved.api_key_keyring is True
             save.assert_called_once()
 
     _run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -282,6 +291,77 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/0b/ba385d8ccedf926c3cd06e8e2f327027da5afe5f0eb30f1f7bc43ac55125/cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004", size = 211037, upload-time = "2026-08-03T21:19:17.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b9/0f2e58b2cefa33255bff36935d42b13180fe559bba82596540eb404bde7d/cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9", size = 218652, upload-time = "2026-08-03T21:19:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/37/15/180e0dab27b9312c7479003d14c9e547634b7dcb934e2cc4650e1b131a7a/cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98", size = 205422, upload-time = "2026-08-03T21:19:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/03026f0c850cbbaa9030750490225b4a7f4d524ea4df72c3cc740a90f4ef/cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9", size = 205444, upload-time = "2026-08-03T21:19:21.246Z" },
+    { url = "https://files.pythonhosted.org/packages/75/77/60bebf6f818bec84210ac5b6979ce4eeadce6fbbaabc9c7ab23e506d1ce5/cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6", size = 218742, upload-time = "2026-08-03T21:19:22.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/679bf47e73fd77b352171727f07de559a003f14de5d02b904a6ec1fa73ca/cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf", size = 221054, upload-time = "2026-08-03T21:19:23.694Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/eefc0e06913b70aa153bf74c946094a18f58fd4aff11b7f372bfdfdca050/cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659", size = 213489, upload-time = "2026-08-03T21:19:24.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/13/4e56852824a03cdf68523a35686f1c28eacd4bd30a7b0a78e682e6e6e1d3/cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9", size = 220241, upload-time = "2026-08-03T21:19:26.214Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
 ]
 
 [[package]]
@@ -409,6 +489,55 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b6/0b9e125e90f3d2dcf599a218a899cda7326a3158cfa258723f0b398b08f6/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a", size = 4692441, upload-time = "2026-07-31T14:24:53.743Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c9/a5151588710785a96d7bc4de27d4cd62f263bbbcb203cfe29df537eb6505/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e", size = 4699810, upload-time = "2026-07-31T14:24:55.746Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1a/15b92b25eb6ce3089cd49377ae990a0f3ad485a510f968aed1f19dbdcdf2/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d", size = 4691924, upload-time = "2026-07-31T14:24:58.082Z" },
+    { url = "https://files.pythonhosted.org/packages/62/15/219075012ab13e8905f3cd572204f4acb4b111df787104346b9bc0cea789/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437", size = 4699593, upload-time = "2026-07-31T14:24:59.951Z" },
+]
+
+[[package]]
 name = "datamodel-code-generator"
 version = "0.64.0"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +564,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "humanize" },
+    { name = "keyring" },
     { name = "pydantic" },
     { name = "pydantic-settings", extra = ["yaml"] },
     { name = "typer" },
@@ -470,6 +600,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "humanize", specifier = ">=4.10.0,<5.0.0" },
+    { name = "keyring", specifier = ">=25.7.0" },
     { name = "pydantic", specifier = ">=2.8.2,<3.0.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.4.0,<3.0.0" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.1,<0.76.0" },
@@ -708,6 +839,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "inflect"
 version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -735,6 +878,51 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -744,6 +932,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -882,6 +1088,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1282,6 +1497,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1556,6 +1780,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1655,6 +1888,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b9/673096d61276f39291b729dddde23c831a5833d98048349835782688a0ec/ruff-0.5.7-py3-none-win32.whl", hash = "sha256:33d61fc0e902198a3e55719f4be6b375b28f860b09c281e4bdbf783c0566576a", size = 7841772, upload-time = "2024-08-08T15:42:57.488Z" },
     { url = "https://files.pythonhosted.org/packages/67/1c/4520c98bfc06b9c73cd1457686d4d3935d40046b1ddea08403e5a6deff51/ruff-0.5.7-py3-none-win_amd64.whl", hash = "sha256:083bbcbe6fadb93cd86709037acc510f86eed5a314203079df174c40bbbca6b3", size = 8699779, upload-time = "2024-08-08T15:43:00.429Z" },
     { url = "https://files.pythonhosted.org/packages/38/23/b3763a237d2523d40a31fe2d1a301191fe392dd48d3014977d079cf8c0bd/ruff-0.5.7-py3-none-win_arm64.whl", hash = "sha256:2dca26154ff9571995107221d0aeaad0e75a77b5a682d6236cf89a58c70b76f4", size = 8091891, upload-time = "2024-08-08T15:43:04.162Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2046,4 +2292,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
     { url = "https://files.pythonhosted.org/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
     { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Closes #48.

## Summary

Store secrets in the OS keychain via the cross-platform [`keyring`](https://pypi.org/project/keyring/) package, usable from both the CLI and the TUI — API keys, git provider credentials and database passwords no longer have to live in YAML files.

## What is in this PR

- **`dokli/secrets.py`** — thin `keyring` wrapper (service `dokli`) with deterministic account names `conn.<name>`, `provider.<name>`, `db.<name>`: `set_secret` / `get_secret` / `delete_secret` (no-op on missing).
- **Models** — resolution order: literal value → keychain → `*_cmd`:
  - `ConnectionConfig.api_key_keyring: bool` → `get_api_key()` checks the keychain before `api_key_cmd`; validator accepts any of the three.
  - `GitProvider.token_keyring` and `DatabaseService.password_keyring` → `apply._resolve_database_password` reads the keychain; token is declarative metadata (git providers are write-only/pre-configured).
- **CLI `dokli secrets set|get|rm|ls`** — `set` hidden prompt or `--stdin`; `get` masked by default with `--show`; `ls` is best-effort (not all keyring backends support listing).
- **`dokli connections add/update --keyring`** — the API key goes to the keychain and the YAML only records `api_key_keyring: true` (never in clear).
- **TUI connection form** — keychain is **on by default for new connections** (secure default); when the keychain toggle is active, `api_key_cmd` is hidden and reset. Saving with the toggle moves the key to the keychain.

## Form fixes found while testing

- `notes` is no longer effectively required: `Form.validate` maps `None` (empty input) to the field default for non-optional fields.
- Live validation is now **debounced (150ms)** — rapid typing/backspace no longer stalls from per-keystroke form reset + re-render.

## Also

- `keyring` added as a core dependency; `tests/conftest.py` provides an in-memory keyring backend; README documents the keychain usage.

## Tests

`tests/test_secrets.py` + keyring cases in config/connections/TUI tests; `make lint` ✓ (ruff + ty), `make test` → 182 passed ✓. Verified against the real keychain (`set`/`get` masked/`get --show`/`rm`) and via the TUI/CLI with meche.
