### PR TITLE
DOKLI-50-f1: schema-driven generic resources (slice 1: domain/port)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ API keys, git provider credentials and database passwords can be stored in your 
 
 - `dokli secrets set|get|rm <account>` — manage keychain entries (accounts like `conn.meche`, `provider.github-main`, `db.backend`); `get` masks by default, `--show` prints in plain text.
 - `dokli connections add <name> --keyring` / `dokli connections update <name> --keyring` — store the API key in the keychain (`api_key_keyring: true`) so it never touches the config file.
-- In manifests, `token_keyring: true` (git providers) and `password_keyring: true` (databases) resolve those secrets from the keychain at apply time.
+- In manifests, `token_keyring: true` (git providers) and `password_keyring: true` (databases) resolve those secrets from the keychain at apply time. Generic `resources:` fields resolve secrets with `{"keyring": "account"}` or `{"cmd": "..."}` in `data`.
 - Resolution order is: literal value → keychain → `*_cmd`.
 
 Uses the cross-platform [`keyring`](https://pypi.org/project/keyring/) package (SecretService / macOS Keychain / Windows Credential Locker).
@@ -133,6 +133,7 @@ $ dokli
 │ state    Show the current state of a Dokploy instance.                              │
 │ plan     Show what would change between the manifest and the live instance.         │
 │ apply    Apply the manifest to a Dokploy instance (idempotent, additive).           │
+│ validate Validate the manifest offline against the connection's schema.             │
 │ export   Export the live state of an instance into a manifest.                      │
 │ api      API commands                                                               │
 │ connections  Manage connections.                                                    │
@@ -184,12 +185,14 @@ Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokpl
 | `dokli state [connection]` | Show the current state of an instance. |
 | `dokli plan [-f dokploy.yaml]` | Preview what would change. |
 | `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy]` | Configure the instance to match the manifest. `--dry-run` only previews; `--deploy` also triggers deployments. |
+| `dokli validate [-f dokploy.yaml]` | Validate the manifest offline against the connection's schema. |
 | `dokli export [connection] [-o file] [--include-secrets]` | Reverse-engineer a live instance into a manifest. |
 
 ### Manifest
 
 ```yaml
 # dokploy.yaml
+apiVersion: v1
 connection: prod
 
 git_providers:
@@ -212,8 +215,24 @@ projects:
         image: nginx:latest
         env: |
           NODE_ENV=production
+
+resources:
+  - kind: domain
+    name: www.example.com
+    in: compose:backend
+    data:
+      host: www.example.com
+      https: true
+  - kind: port
+    name: 8080
+    in: application:web
+    data:
+      publishedPort: 8080
+      targetPort: 80
+      protocol: tcp
 ```
 
+- `apiVersion` is the Dokli manifest format version (only `v1` today); `dokployVersion` (the Dokploy API version the manifest was written against) is stamped by `init`/`export`.
 - Services live in the project's **default environment** (Dokploy creates one per project).
 - `compose_file` accepts raw compose YAML or a path to a local file (mutually exclusive with `source`).
 - **Secrets are never stored in the manifest.** Git provider credentials are write-only in Dokploy's API; reference them with `token_cmd` (same pattern as `api_key_cmd`). `export` redacts service environment variables by default (`--include-secrets` to include them) and reports which providers need credentials.
@@ -229,6 +248,39 @@ projects:
         name: db
         password_cmd: "ansible-vault view --vault-password-file ~/.vault-pass secrets/vault.yml | yq -r '.db_password'"
 ```
+
+### Generic resources
+
+`projects:` describes the services themselves (the typed backbone: state, plan/apply, deploy). `resources:` describes the **leaf records** that hang off those services — domains, ports, redirects, security, schedules, backups, mounts. They are resolved against the connection's OpenAPI document, so any field (or future entity) is supported without a code change.
+
+A resource has `kind`, `name`, `in` (the parent path) and `data` (the create/update fields; parent ids are derived from `in`, never repeated in `data`):
+
+```yaml
+resources:
+  - kind: domain
+    name: www.example.com
+    in: project:myapp / environment:production / compose:backend
+    data:
+      host: www.example.com
+      https: true
+```
+
+- **`in`** is a `<kind>:<name>` path to the parent service. Ancestor segments (`project:`, `environment:`) scope the lookup and disambiguate same-named services across projects. `in: compose:backend` alone matches globally.
+- **Matching** is string-based on a per-kind match key, falling back to `name`: `domain → host`, `port → publishedPort`, `redirects → regex`, `security → username`, `mount → filePath`, `backup → schedule`.
+- **Parent restrictions**: `port`/`security`/`redirects` hang off `application` services only; `domain` off `application`/`compose`; `mount` off any service. `dokli validate` flags violations.
+- **Secrets in `data`** use the same dict references as elsewhere: `{"cmd": "..."}` (run through a shell) or `{"keyring": "account"}` (from your OS keychain):
+
+```yaml
+resources:
+  - kind: security
+    name: admin
+    in: application:web
+    data:
+      username: admin
+      password: {keyring: app-web-admin}
+```
+
+`apply` is additive here too: an existing resource is updated, a missing one is created, and nothing is ever deleted because it is absent from the manifest.
 
 ### Workflow
 

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -7,44 +7,16 @@ desired state (the API splits ``create`` and ``update`` inputs).
 
 import secrets
 import subprocess
-from typing import Any, Literal
-
-from pydantic import BaseModel, Field
+from typing import Any
 
 from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.diff import resolve_compose_file
 from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Service
+from dokli.report import ApplyAction, ApplyReport
+from dokli.resources import ResourceManager
 from dokli.secrets import db_account, get_secret
 from dokli.state import LiveGitProvider, LiveProject, LiveService, State, collect_state
-
-
-class ApplyAction(BaseModel):
-    """A single apply action."""
-
-    action: Literal["create", "update", "validate", "skip"]
-    kind: Literal[
-        "project",
-        "environment",
-        "compose",
-        "application",
-        "postgres",
-        "mysql",
-        "mariadb",
-        "mongo",
-        "redis",
-        "git_provider",
-    ]
-    project: str = ""
-    name: str
-    details: str = ""
-
-
-class ApplyReport(BaseModel):
-    """Report of what apply did or would do."""
-
-    actions: list[ApplyAction] = Field(default_factory=list)
-    warnings: list[str] = Field(default_factory=list)
 
 
 class Applier:
@@ -74,6 +46,8 @@ class Applier:
                 self._create_project(project_def, dry_run)
             else:
                 self._apply_to_project(project_def, live_project, dry_run)
+
+        ResourceManager(self).run(dry_run)
 
         return self.report
 

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -49,8 +49,9 @@ class Applier:
 
         # Re-capture the state so generic resources can attach to services that
         # were just created by the typed apply above.
-        self._state = collect_state(self.connection, client=self.client)
-        ResourceManager(self).run(dry_run)
+        if self.manifest.resources:
+            self._state = collect_state(self.connection, client=self.client)
+            ResourceManager(self).run(dry_run)
 
         return self.report
 

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -47,6 +47,9 @@ class Applier:
             else:
                 self._apply_to_project(project_def, live_project, dry_run)
 
+        # Re-capture the state so generic resources can attach to services that
+        # were just created by the typed apply above.
+        self._state = collect_state(self.connection, client=self.client)
         ResourceManager(self).run(dry_run)
 
         return self.report

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -8,7 +8,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from dokli.api_client import APIClient
-from dokli.apply import Applier, ApplyReport
+from dokli.apply import Applier
 from dokli.config import Config, ConnectionConfig
 from dokli.connections import build_command as build_connections_command
 from dokli.diff import build_plan
@@ -17,8 +17,10 @@ from dokli.formatting import redact_secrets
 from dokli.init import init_manifest
 from dokli.manifest import Manifest
 from dokli.openapi_cli import build_command as build_api_command
+from dokli.report import ApplyReport
 from dokli.secrets_cli import build_command as build_secrets_command
 from dokli.state import collect_state
+from dokli.validate import validate_manifest
 
 try:
     from dokli.tui.app import app as tui
@@ -150,6 +152,21 @@ def apply_command(
     applier = Applier(manifest, connection, deploy=deploy)
     report = applier.run(dry_run=dry_run)
     _print_apply_report(report)
+
+
+@app.command(name="validate")
+def validate_command(
+    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+) -> None:
+    """Validate a manifest offline against the connection's schema."""
+    manifest = Manifest.load(manifest_file)
+    connection = _get_connection(manifest.connection)
+    issues = validate_manifest(connection, manifest)
+    if issues:
+        for issue in issues:
+            rprint(f"[yellow]{issue}[/yellow]")
+        raise typer.Exit(code=1)
+    rprint("[green]Manifest is valid.[/green]")
 
 
 @app.command(name="export")

--- a/dokli/init.py
+++ b/dokli/init.py
@@ -8,12 +8,16 @@ TEMPLATE = """\
 # Dokli as Code manifest.
 #
 # Describes the desired state of a Dokploy instance. Apply it with:
-#   dokli apply            # configure the instance to match this file
-#   dokli plan             # preview changes first
+#   dokli validate          # offline validation against the connection's schema
+#   dokli apply             # configure the instance to match this file
+#   dokli plan              # preview changes first
 #
 # connection: name of a connection defined in your dokli config.
 
 connection: {connection}
+
+# Dokli manifest format version (only "v1" today).
+apiVersion: v1
 
 # Git providers are referenced by services. Credentials are write-only in
 # Dokploy's API, so configure providers in the instance and resolve the
@@ -27,6 +31,26 @@ connection: {connection}
 #     token_cmd: "secret-tool lookup dokli github-main"
 
 projects: []
+
+# Generic schema-driven resources: leaf records (domains, ports, ...) that hang
+# off a service declared in "projects" above. "in" is the parent path; "data"
+# holds the create/update fields. Secrets in "data" can be resolved with
+# {{"cmd": "..."}} or {{"keyring": "account"}}.
+#
+# resources:
+#   - kind: domain
+#     name: www.example.com
+#     in: compose:backend
+#     data:
+#       host: www.example.com
+#       https: true
+#   - kind: port
+#     name: 8080
+#     in: application:web
+#     data:
+#       publishedPort: 8080
+#       targetPort: 80
+#       protocol: tcp
 """
 
 

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -1,13 +1,13 @@
 """Declarative manifest models for Dokli as Code.
 
-The manifest (``dokli.yaml``) describes the desired state of a Dokploy
-instance. See :issue:`20`.
+The manifest (``dokploy.yaml``) describes the desired state of a Dokploy
+instance. See :issue:`20` and :issue:`50`.
 """
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class GitProvider(BaseModel):
@@ -135,9 +135,37 @@ class ProjectDef(BaseModel):
     )
 
 
+class Resource(BaseModel):
+    """A generic schema-driven resource (issue #50).
+
+    ``kind`` is an entity from the OpenAPI registry, ``name`` is the match
+    key, ``in`` is the explicit parent path (``<kind>:<name>[/<kind>:<name>]``)
+    and ``data`` holds the create/update fields. Parent ids are derived from
+    ``in``, never repeated in ``data``. Secret fields in ``data`` use dict
+    references: ``{"cmd": ...}`` or ``{"keyring": ...}``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: str
+    name: str
+    in_: str | None = Field(
+        default=None,
+        alias="in",
+        description="Parent path, e.g. compose:torrents or project:media / environment:production.",
+    )
+    data: dict[str, Any] = Field(default_factory=dict, description="Create/update fields for the resource.")
+
+
 class Manifest(BaseModel):
     """Dokli as Code manifest."""
 
+    api_version: str = Field(default="v1", alias="apiVersion", description="Dokli manifest format version.")
+    dokploy_version: str | None = Field(
+        default=None,
+        alias="dokployVersion",
+        description="Dokploy API version the manifest was written against (stamped by init/export).",
+    )
     connection: str = Field(..., description="Connection name from dokli's config.")
     server: str | None = Field(
         default=None,
@@ -145,6 +173,10 @@ class Manifest(BaseModel):
     )
     git_providers: list[GitProvider] = Field(default_factory=list)
     projects: list[ProjectDef] = Field(default_factory=list)
+    resources: list[Resource] = Field(
+        default_factory=list,
+        description="Generic schema-driven resources (issue #50).",
+    )
 
     def get_git_provider(self, name: str) -> GitProvider:
         """Get a git provider by name.
@@ -159,6 +191,10 @@ class Manifest(BaseModel):
 
     @classmethod
     def load(cls, path: str) -> "Manifest":
-        """Load a manifest from a YAML file."""
+        """Load a manifest from a YAML file, validating the apiVersion."""
         with open(path) as file:
-            return cls.model_validate(yaml.safe_load(file))
+            data = yaml.safe_load(file) or {}
+        api_version = data.get("apiVersion", "v1")
+        if api_version != "v1":
+            raise ValueError(f"Unsupported manifest apiVersion '{api_version}' (expected 'v1').")
+        return cls.model_validate(data)

--- a/dokli/report.py
+++ b/dokli/report.py
@@ -1,0 +1,22 @@
+"""Apply report models."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ApplyAction(BaseModel):
+    """A single apply action."""
+
+    action: Literal["create", "update", "validate", "skip"]
+    kind: str
+    project: str = ""
+    name: str
+    details: str = ""
+
+
+class ApplyReport(BaseModel):
+    """Report of what apply did or would do."""
+
+    actions: list[ApplyAction] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/dokli/resources.py
+++ b/dokli/resources.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from dokli.manifest import Resource
 from dokli.report import ApplyAction
+from dokli.tui.engine import parse_spec
 from dokli.tui.engine.spec import NESTED_CHILD_KEYS
 
 if TYPE_CHECKING:
@@ -108,6 +109,8 @@ class ResourceManager:
         self.client = applier.client
         self.report = applier.report
         self.state: State = applier._state
+        schema = getattr(self.client, "schema", None)
+        self.registry = parse_spec(schema) if isinstance(schema, dict) else {}
 
     def run(self, dry_run: bool = False) -> None:
         """Apply all generic resources."""
@@ -128,6 +131,11 @@ class ResourceManager:
     def _apply_service_child(self, resource: Resource, parent_kind: str, parent_name: str, dry_run: bool) -> None:
         service = self._find_live_service(parent_kind, parent_name)
         if service is None:
+            if dry_run:
+                # The parent service does not exist yet (it will be created by
+                # the typed apply); record the planned create.
+                self.report.actions.append(ApplyAction(action="create", kind=resource.kind, name=resource.name))
+                return
             raise ValueError(
                 f"Parent service '{parent_kind}:{parent_name}' not found in the instance "
                 "(declare it in 'projects:' so it is created first)."
@@ -139,14 +147,19 @@ class ResourceManager:
         child = next((c for c in children if str(c.get(key)) == value), None)
 
         parent_field = "serviceId" if resource.kind == "mount" else f"{parent_kind}Id"
-        body = {**resolve_data(resource.data), parent_field: service.service_id, key: value}
+        body = {**resolve_data(resource.data), parent_field: service.service_id}
+        # The match key only falls back to the resource name when the data omits
+        # it; matching itself is string-based, but the payload keeps the data types.
+        if key not in body:
+            body[key] = resource.name
         if resource.kind == "mount":
             body["serviceType"] = parent_kind
 
         if child is None:
             action = "create"
             if not dry_run:
-                self.client.request("POST", f"{resource.kind}.create", {"body": body})
+                create_body = self._create_body(resource.kind, body)
+                self.client.request("POST", f"{resource.kind}.create", {"body": create_body})
         elif self._changed(child, body):
             action = "update"
             if not dry_run:
@@ -177,6 +190,24 @@ class ResourceManager:
         """Whether the live child differs from the desired body.
 
         Only fields present on the live record are compared (parent ids and
-        read-only fields are excluded).
+        read-only fields are excluded), using string comparison so int/string
+        representation differences do not cause spurious updates.
         """
-        return any(live.get(field) != value for field, value in body.items() if field in live)
+        return any(
+            str(live.get(field)) != str(value) for field, value in body.items() if field in live
+        )
+
+    def _create_body(self, kind: str, body: dict) -> dict:
+        """Fill required create fields that have a schema default but are absent."""
+        entity = self.registry.get(kind)
+        create = entity.get("create") if entity else None
+        if create is None:
+            return body
+        props = create.request_schema.get("properties", {})
+        filled = dict(body)
+        for field in create.request_schema.get("required", []):
+            if field not in filled:
+                prop = props.get(field, {})
+                if "default" in prop:
+                    filled[field] = prop["default"]
+        return filled

--- a/dokli/resources.py
+++ b/dokli/resources.py
@@ -1,0 +1,182 @@
+"""Generic schema-driven resources (issue #50).
+
+A generic manifest resource (``kind`` + ``name`` + ``in`` + ``data``) is
+resolved against the entity registry and the live instance. The schema
+conventions are followed by default; the curated maps below cover the known
+historical exceptions (kinds without a stable ``name``, parents addressed via
+``serviceId`` instead of ``<parent>Id``).
+"""
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from dokli.manifest import Resource
+from dokli.report import ApplyAction
+from dokli.tui.engine.spec import NESTED_CHILD_KEYS
+
+if TYPE_CHECKING:
+    from dokli.state import State
+
+# Kinds whose match key is not their ``name`` field (historical exceptions).
+MATCH_KEYS: dict[str, str] = {
+    "domain": "host",
+    "port": "publishedPort",
+    "redirects": "regex",
+    "security": "username",
+    "mount": "filePath",
+    "backup": "schedule",
+}
+
+# Child kind -> the nested array key on the parent service record.
+CHILD_ARRAY: dict[str, str] = {child: key for key, child in NESTED_CHILD_KEYS.items()}
+
+# Service kinds that can host leaf resources.
+SERVICE_KINDS = frozenset(
+    {"compose", "application", "postgres", "mysql", "mariadb", "mongo", "redis", "libsql"}
+)
+
+
+def match_key(kind: str) -> str:
+    """The field used to match a resource kind against the live instance."""
+    return MATCH_KEYS.get(kind, "name")
+
+
+def child_array_key(kind: str) -> str:
+    """The nested array key of a child kind on the parent service record."""
+    try:
+        return CHILD_ARRAY[kind]
+    except KeyError:
+        raise ValueError(f"Kind '{kind}' is not a known child resource.") from None
+
+
+def parse_in(path: str | None) -> list[tuple[str, str]]:
+    """Parse an ``in`` path into ``(kind, name)`` segments.
+
+    Segments are ``<kind>:<name>``, e.g. ``compose:torrents`` or
+    ``project:media / environment:production / compose:torrents``.
+    """
+    segments: list[tuple[str, str]] = []
+    for raw in (path or "").split("/"):
+        part = raw.strip()
+        if not part:
+            continue
+        if ":" in part:
+            kind, name = part.split(":", 1)
+            segments.append((kind.strip(), name.strip()))
+        else:
+            segments.append(("", part))
+    return segments
+
+
+def match_value(resource: Resource, key: str) -> str:
+    """The value to match on, falling back to the resource name."""
+    return str(resource.data.get(key) or resource.name)
+
+
+def resolve_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Resolve secret references (``{"cmd": ...}`` / ``{"keyring": ...}``) in data."""
+    return {key: _resolve_secret(value) for key, value in data.items()}
+
+
+def _resolve_secret(value: Any) -> Any:
+    if isinstance(value, dict) and set(value) <= {"cmd", "keyring"}:
+        if "cmd" in value:
+            raw = subprocess.check_output(str(value["cmd"]), shell=True)
+            return raw.decode("utf-8").strip()
+        if "keyring" in value:
+            from dokli.secrets import get_secret
+
+            secret = get_secret(str(value["keyring"]))
+            if secret is None:
+                raise ValueError(f"No secret stored for '{value['keyring']}'.")
+            return secret
+    return value
+
+
+class ResourceManager:
+    """Applies generic manifest resources against a connection.
+
+    Slice 1 covers leaf resources (domain, port, ...) hanging off a service
+    declared in the manifest's typed ``projects``. Ancestors (project,
+    environment, service) are resolved from the live state.
+    """
+
+    def __init__(self, applier) -> None:
+        """Construct the resource manager sharing the applier's client/report."""
+        self.applier = applier
+        self.manifest = applier.manifest
+        self.client = applier.client
+        self.report = applier.report
+        self.state: State = applier._state
+
+    def run(self, dry_run: bool = False) -> None:
+        """Apply all generic resources."""
+        for resource in self.manifest.resources:
+            self._apply_resource(resource, dry_run)
+
+    def _apply_resource(self, resource: Resource, dry_run: bool) -> None:
+        segments = parse_in(resource.in_)
+        if not segments:
+            raise ValueError(f"Resource '{resource.kind}:{resource.name}' must declare its parent via 'in:'.")
+        parent_kind, parent_name = segments[-1]
+        if parent_kind not in SERVICE_KINDS:
+            raise ValueError(
+                f"Resource '{resource.kind}:{resource.name}' parent '{parent_kind}' is not supported yet."
+            )
+        self._apply_service_child(resource, parent_kind, parent_name, dry_run)
+
+    def _apply_service_child(self, resource: Resource, parent_kind: str, parent_name: str, dry_run: bool) -> None:
+        service = self._find_live_service(parent_kind, parent_name)
+        if service is None:
+            raise ValueError(
+                f"Parent service '{parent_kind}:{parent_name}' not found in the instance "
+                "(declare it in 'projects:' so it is created first)."
+            )
+        record = self.client.request("GET", f"{parent_kind}.one", {f"{parent_kind}Id": service.service_id}).json()
+        key = match_key(resource.kind)
+        value = match_value(resource, key)
+        children = record.get(child_array_key(resource.kind)) or []
+        child = next((c for c in children if str(c.get(key)) == value), None)
+
+        parent_field = "serviceId" if resource.kind == "mount" else f"{parent_kind}Id"
+        body = {**resolve_data(resource.data), parent_field: service.service_id, key: value}
+        if resource.kind == "mount":
+            body["serviceType"] = parent_kind
+
+        if child is None:
+            action = "create"
+            if not dry_run:
+                self.client.request("POST", f"{resource.kind}.create", {"body": body})
+        elif self._changed(child, body):
+            action = "update"
+            if not dry_run:
+                entity_id = child[f"{resource.kind}Id"]
+                update_body = {**body, f"{resource.kind}Id": entity_id}
+                self.client.request("POST", f"{resource.kind}.update", {"body": update_body})
+        else:
+            action = "skip"
+        self.report.actions.append(
+            ApplyAction(action=action, kind=resource.kind, name=resource.name)
+        )
+
+    def _find_live_service(self, kind: str, name: str):
+        """Find a live service by kind + name, or None (error on ambiguity)."""
+        matches = []
+        for project in self.state.projects:
+            for environment in project.environments:
+                for service in environment.services:
+                    if service.type == kind and service.name == name:
+                        matches.append(service)
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise ValueError(f"Ambiguous parent service '{kind}:{name}' (matches multiple projects).")
+        return matches[0]
+
+    def _changed(self, live: dict, body: dict) -> bool:
+        """Whether the live child differs from the desired body.
+
+        Only fields present on the live record are compared (parent ids and
+        read-only fields are excluded).
+        """
+        return any(live.get(field) != value for field, value in body.items() if field in live)

--- a/dokli/resources.py
+++ b/dokli/resources.py
@@ -4,7 +4,8 @@ A generic manifest resource (``kind`` + ``name`` + ``in`` + ``data``) is
 resolved against the entity registry and the live instance. The schema
 conventions are followed by default; the curated maps below cover the known
 historical exceptions (kinds without a stable ``name``, parents addressed via
-``serviceId`` instead of ``<parent>Id``).
+``serviceId`` instead of ``<parent>Id``, entities whose API name differs from
+the manifest ``kind``).
 """
 
 import subprocess
@@ -28,6 +29,30 @@ MATCH_KEYS: dict[str, str] = {
     "backup": "schedule",
 }
 
+# Manifest kind -> API entity name when they differ.
+ENTITY_NAMES: dict[str, str] = {
+    "mount": "mounts",
+}
+
+# Kinds that address their parent with a specific id field (default <parent>Id).
+PARENT_ID_FIELDS: dict[str, str] = {
+    "mount": "serviceId",
+    "port": "applicationId",
+    "security": "applicationId",
+    "redirects": "applicationId",
+}
+
+# Kinds that only hang off specific service parents (None = any service).
+PARENT_KINDS: dict[str, set[str] | None] = {
+    "domain": {"application", "compose", "previewDeployment"},
+    "port": {"application"},
+    "security": {"application"},
+    "redirects": {"application"},
+    "schedule": {"application", "compose"},
+    "backup": {"postgres", "mysql", "mariadb", "mongo", "redis", "libsql", "compose"},
+    "mount": None,
+}
+
 # Child kind -> the nested array key on the parent service record.
 CHILD_ARRAY: dict[str, str] = {child: key for key, child in NESTED_CHILD_KEYS.items()}
 
@@ -48,6 +73,11 @@ def child_array_key(kind: str) -> str:
         return CHILD_ARRAY[kind]
     except KeyError:
         raise ValueError(f"Kind '{kind}' is not a known child resource.") from None
+
+
+def entity_name(kind: str) -> str:
+    """The API entity name for a manifest kind."""
+    return ENTITY_NAMES.get(kind, kind)
 
 
 def parse_in(path: str | None) -> list[tuple[str, str]]:
@@ -99,7 +129,8 @@ class ResourceManager:
 
     Slice 1 covers leaf resources (domain, port, ...) hanging off a service
     declared in the manifest's typed ``projects``. Ancestors (project,
-    environment, service) are resolved from the live state.
+    environment, service) are resolved from the live state, honoring the
+    ``in`` path.
     """
 
     def __init__(self, applier) -> None:
@@ -126,56 +157,80 @@ class ResourceManager:
             raise ValueError(
                 f"Resource '{resource.kind}:{resource.name}' parent '{parent_kind}' is not supported yet."
             )
-        self._apply_service_child(resource, parent_kind, parent_name, dry_run)
-
-    def _apply_service_child(self, resource: Resource, parent_kind: str, parent_name: str, dry_run: bool) -> None:
-        service = self._find_live_service(parent_kind, parent_name)
-        if service is None:
-            if dry_run:
-                # The parent service does not exist yet (it will be created by
-                # the typed apply); record the planned create.
-                self.report.actions.append(ApplyAction(action="create", kind=resource.kind, name=resource.name))
-                return
+        allowed = PARENT_KINDS.get(resource.kind)
+        if allowed is not None and parent_kind not in allowed:
             raise ValueError(
-                f"Parent service '{parent_kind}:{parent_name}' not found in the instance "
-                "(declare it in 'projects:' so it is created first)."
+                f"Resource '{resource.kind}:{resource.name}' cannot hang off '{parent_kind}' "
+                f"(allowed: {', '.join(sorted(allowed))})."
             )
+        self._apply_service_child(resource, parent_kind, parent_name, segments[:-1], dry_run)
+
+    def _apply_service_child(
+        self,
+        resource: Resource,
+        parent_kind: str,
+        parent_name: str,
+        ancestors: list[tuple[str, str]],
+        dry_run: bool,
+    ) -> None:
+        service = self._find_live_service(parent_kind, parent_name, ancestors)
+        if service is None:
+            # Record a validation action instead of aborting after a partial apply.
+            self.report.actions.append(
+                ApplyAction(
+                    action="skip",
+                    kind=resource.kind,
+                    name=resource.name,
+                    details=f"Parent service '{parent_kind}:{parent_name}' not found.",
+                )
+            )
+            return
         record = self.client.request("GET", f"{parent_kind}.one", {f"{parent_kind}Id": service.service_id}).json()
         key = match_key(resource.kind)
         value = match_value(resource, key)
         children = record.get(child_array_key(resource.kind)) or []
         child = next((c for c in children if str(c.get(key)) == value), None)
 
-        parent_field = "serviceId" if resource.kind == "mount" else f"{parent_kind}Id"
+        parent_field = PARENT_ID_FIELDS.get(resource.kind, f"{parent_kind}Id")
         body = {**resolve_data(resource.data), parent_field: service.service_id}
         # The match key only falls back to the resource name when the data omits
         # it; matching itself is string-based, but the payload keeps the data types.
         if key not in body:
-            body[key] = resource.name
+            body[key] = self._coerce(resource.kind, key, resource.name)
         if resource.kind == "mount":
             body["serviceType"] = parent_kind
 
+        entity = entity_name(resource.kind)
         if child is None:
             action = "create"
             if not dry_run:
                 create_body = self._create_body(resource.kind, body)
-                self.client.request("POST", f"{resource.kind}.create", {"body": create_body})
+                self.client.request("POST", f"{entity}.create", {"body": create_body})
         elif self._changed(child, body):
             action = "update"
             if not dry_run:
-                entity_id = child[f"{resource.kind}Id"]
-                update_body = {**body, f"{resource.kind}Id": entity_id}
-                self.client.request("POST", f"{resource.kind}.update", {"body": update_body})
+                entity_id = child[f"{entity}Id"]
+                update_body = {**body, f"{entity}Id": entity_id}
+                self.client.request("POST", f"{entity}.update", {"body": update_body})
         else:
             action = "skip"
         self.report.actions.append(
             ApplyAction(action=action, kind=resource.kind, name=resource.name)
         )
 
-    def _find_live_service(self, kind: str, name: str):
-        """Find a live service by kind + name, or None (error on ambiguity)."""
+    def _find_live_service(self, kind: str, name: str, ancestors: list[tuple[str, str]]):
+        """Find a live service by kind + name, honoring the ancestor path.
+
+        Returns None when not found; raises on ambiguity.
+        """
+        projects = self.state.projects
+        for seg_kind, seg_name in ancestors:
+            if seg_kind == "project":
+                projects = [p for p in projects if p.name == seg_name]
+            elif seg_kind == "environment":
+                projects = [p for p in projects if seg_name in {e.name for e in p.environments}]
         matches = []
-        for project in self.state.projects:
+        for project in projects:
             for environment in project.environments:
                 for service in environment.services:
                     if service.type == kind and service.name == name:
@@ -189,17 +244,19 @@ class ResourceManager:
     def _changed(self, live: dict, body: dict) -> bool:
         """Whether the live child differs from the desired body.
 
-        Only fields present on the live record are compared (parent ids and
-        read-only fields are excluded), using string comparison so int/string
-        representation differences do not cause spurious updates.
+        Id fields (parents/entity) are excluded. Any desired field missing from
+        the live record counts as a change so it gets set, not silently skipped.
         """
-        return any(
-            str(live.get(field)) != str(value) for field, value in body.items() if field in live
-        )
+        for field, value in body.items():
+            if field.endswith("Id"):
+                continue
+            if field not in live or str(live.get(field)) != str(value):
+                return True
+        return False
 
     def _create_body(self, kind: str, body: dict) -> dict:
         """Fill required create fields that have a schema default but are absent."""
-        entity = self.registry.get(kind)
+        entity = self.registry.get(entity_name(kind))
         create = entity.get("create") if entity else None
         if create is None:
             return body
@@ -211,3 +268,19 @@ class ResourceManager:
                 if "default" in prop:
                     filled[field] = prop["default"]
         return filled
+
+    def _coerce(self, kind: str, field: str, value: str) -> Any:
+        """Coerce a fallback match value to the schema type when numeric."""
+        entity = self.registry.get(entity_name(kind))
+        create = entity.get("create") if entity is not None else None
+        schema = create.request_schema if create is not None else None
+        if schema is None:
+            update = entity.get("update") if entity is not None else None
+            schema = update.request_schema if update is not None else None
+        prop = (schema or {}).get("properties", {}).get(field, {})
+        if prop.get("type") in ("number", "integer"):
+            try:
+                return int(value) if prop.get("type") == "integer" else float(value)
+            except ValueError:
+                return value
+        return value

--- a/dokli/validate.py
+++ b/dokli/validate.py
@@ -3,7 +3,13 @@
 from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.manifest import Manifest
-from dokli.resources import MATCH_KEYS, SERVICE_KINDS, parse_in
+from dokli.resources import (
+    MATCH_KEYS,
+    PARENT_KINDS,
+    SERVICE_KINDS,
+    entity_name,
+    parse_in,
+)
 from dokli.tui.engine import parse_spec
 
 
@@ -16,7 +22,7 @@ def validate_manifest(connection: ConnectionConfig, manifest: Manifest) -> list[
     registry = parse_spec(APIClient(connection).schema)
     for resource in manifest.resources:
         label = f"{resource.kind}:{resource.name}"
-        entity = registry.get(resource.kind)
+        entity = registry.get(entity_name(resource.kind))
         if entity is None:
             issues.append(f"resource {label}: unknown kind '{resource.kind}'.")
             continue
@@ -41,4 +47,11 @@ def validate_manifest(connection: ConnectionConfig, manifest: Manifest) -> list[
         parent_kind, _ = segments[-1]
         if parent_kind not in SERVICE_KINDS:
             issues.append(f"resource {label}: parent '{parent_kind}' is not supported yet.")
+            continue
+        allowed = PARENT_KINDS.get(resource.kind)
+        if allowed is not None and parent_kind not in allowed:
+            issues.append(
+                f"resource {label}: cannot hang off '{parent_kind}' "
+                f"(allowed: {', '.join(sorted(allowed))})."
+            )
     return issues

--- a/dokli/validate.py
+++ b/dokli/validate.py
@@ -1,0 +1,44 @@
+"""Offline manifest validation against the connection's schema (issue #50)."""
+
+from dokli.api_client import APIClient
+from dokli.config import ConnectionConfig
+from dokli.manifest import Manifest
+from dokli.resources import MATCH_KEYS, SERVICE_KINDS, parse_in
+from dokli.tui.engine import parse_spec
+
+
+def validate_manifest(connection: ConnectionConfig, manifest: Manifest) -> list[str]:
+    """Validate a manifest against the connection's schema.
+
+    Returns a list of issues (empty when valid).
+    """
+    issues = []
+    registry = parse_spec(APIClient(connection).schema)
+    for resource in manifest.resources:
+        label = f"{resource.kind}:{resource.name}"
+        entity = registry.get(resource.kind)
+        if entity is None:
+            issues.append(f"resource {label}: unknown kind '{resource.kind}'.")
+            continue
+        create = entity.get("create")
+        update = entity.get("update")
+        if create is None or update is None:
+            issues.append(f"resource {label}: kind lacks create/update actions.")
+            continue
+        props = set(create.request_schema.get("properties", {})) | set(
+            update.request_schema.get("properties", {})
+        )
+        for field in resource.data:
+            if field not in props:
+                issues.append(f"resource {label}: unknown field '{field}'.")
+        key = MATCH_KEYS.get(resource.kind, "name")
+        if key not in props:
+            issues.append(f"resource {label}: match key '{key}' is not in the schema.")
+        segments = parse_in(resource.in_)
+        if not segments:
+            issues.append(f"resource {label}: missing 'in:'.")
+            continue
+        parent_kind, _ = segments[-1]
+        if parent_kind not in SERVICE_KINDS:
+            issues.append(f"resource {label}: parent '{parent_kind}' is not supported yet.")
+    return issues

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,11 +3,46 @@
 import pytest
 import yaml
 
-from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest
+from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Resource
 
 
 def _load_manifest(raw_yaml: str) -> Manifest:
     return Manifest.model_validate(yaml.safe_load(raw_yaml))
+
+
+class TestResource:
+    """Generic resource model tests (issue #50)."""
+
+    def test_in_alias(self):
+        """We expect the in field to be populated from the YAML `in` key."""
+        resource = Resource.model_validate({"kind": "domain", "name": "x.example.com", "in": "compose:web", "data": {"host": "x.example.com"}})
+        assert resource.in_ == "compose:web"
+
+    def test_manifest_resources_and_version(self):
+        """We expect the manifest to carry resources, apiVersion and dokployVersion."""
+        manifest = _load_manifest(
+            """
+            apiVersion: v1
+            dokployVersion: "0.29.13"
+            connection: prod
+            resources:
+              - kind: domain
+                name: x.example.com
+                in: compose:web
+                data: { host: x.example.com }
+            """
+        )
+        assert manifest.api_version == "v1"
+        assert manifest.dokploy_version == "0.29.13"
+        assert len(manifest.resources) == 1
+        assert manifest.resources[0].kind == "domain"
+
+    def test_load_rejects_unknown_api_version(self, tmp_path):
+        """We expect an unsupported apiVersion to fail on load."""
+        target = tmp_path / "dokploy.yaml"
+        target.write_text("apiVersion: v2\nconnection: prod\n")
+        with pytest.raises(ValueError):
+            Manifest.load(str(target))
 
 
 class TestManifest:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,214 @@
+"""Generic resources tests (issue #50)."""
+
+import pytest
+
+from dokli.manifest import Manifest, Resource
+from dokli.report import ApplyReport
+from dokli.resources import (
+    CHILD_ARRAY,
+    MATCH_KEYS,
+    SERVICE_KINDS,
+    ResourceManager,
+    child_array_key,
+    match_key,
+    parse_in,
+    resolve_data,
+)
+
+
+class TestMaps:
+    """Curated resource maps."""
+
+    def test_match_keys(self):
+        """We expect the curated match keys for kinds without a stable name."""
+        assert MATCH_KEYS["domain"] == "host"
+        assert MATCH_KEYS["port"] == "publishedPort"
+        assert MATCH_KEYS["mount"] == "filePath"
+        assert match_key("compose") == "name"
+
+    def test_child_array_keys(self):
+        """We expect child kinds to map to their nested array key."""
+        assert child_array_key("domain") == "domains"
+        assert child_array_key("port") == "ports"
+        assert child_array_key("mount") == "mounts"
+        assert CHILD_ARRAY["backup"] == "backups"
+
+    def test_parse_in(self):
+        """We expect in paths to parse into (kind, name) segments."""
+        assert parse_in("compose:torrents") == [("compose", "torrents")]
+        assert parse_in("project:media / environment:production / compose:web") == [
+            ("project", "media"),
+            ("environment", "production"),
+            ("compose", "web"),
+        ]
+        assert parse_in(None) == []
+
+    def test_resolve_data(self, fake_keyring):
+        """We expect dict secret refs to resolve at apply time."""
+        fake_keyring.store[("dokli", "db.main")] = "secret"
+        assert resolve_data({"databasePassword": {"keyring": "db.main"}}) == {"databasePassword": "secret"}
+
+
+def _service(kind, name, service_id):
+    return type("S", (), {"type": kind, "name": name, "service_id": service_id})()
+
+
+def _state(services):
+    project = type(
+        "P",
+        (),
+        {
+            "name": "media",
+            "environments": [
+                type("E", (), {"name": "production", "environment_id": "e1", "services": services})()
+            ],
+        },
+    )()
+    return type("S", (), {"projects": [project]})()
+
+
+class FakeClient:
+    """Minimal APIClient stand-in returning configurable records."""
+
+    def __init__(self, records=None):
+        self.calls = []
+        self.records = records or {}
+
+    def request(self, method, path, params):
+        self.calls.append((method, path, params))
+        record = self.records.get(path, {})
+
+        class _Response:
+            def json(self):
+                return record
+
+        return _Response()
+
+
+def _manager(manifest, client, services):
+    applier = type("A", (), {})()
+    applier.manifest = manifest
+    applier.client = client
+    applier.report = ApplyReport()
+    applier._state = _state(services)
+    return ResourceManager(applier)
+
+
+def _manifest(*resources):
+    return Manifest(connection="test", resources=list(resources))
+
+
+class TestResourceManager:
+    """Generic leaf resource application."""
+
+    def test_create_domain(self):
+        """We expect a missing domain to be created with its parent id."""
+        client = FakeClient({"compose.one": {"composeId": "c1", "domains": []}})
+        manager = _manager(
+            _manifest(Resource(kind="domain", name="x.example.com", in_="compose:web", data={"host": "x.example.com"})),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run()
+        create = next(c for c in client.calls if c[1] == "domain.create")
+        assert create[2] == {"body": {"host": "x.example.com", "composeId": "c1"}}
+        assert manager.report.actions[0].action == "create"
+        assert manager.report.actions[0].kind == "domain"
+
+    def test_update_domain(self):
+        """We expect a changed domain to be updated."""
+        client = FakeClient(
+            {
+                "compose.one": {
+                    "composeId": "c1",
+                    "domains": [{"domainId": "d1", "host": "x.example.com", "port": 80}],
+                }
+            }
+        )
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="domain",
+                    name="x.example.com",
+                    in_="compose:web",
+                    data={"host": "x.example.com", "port": 443},
+                )
+            ),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run()
+        update = next(c for c in client.calls if c[1] == "domain.update")
+        assert update[2] == {"body": {"host": "x.example.com", "port": 443, "composeId": "c1", "domainId": "d1"}}
+        assert manager.report.actions[0].action == "update"
+
+    def test_skip_unchanged_domain(self):
+        """We expect an unchanged domain to be skipped."""
+        client = FakeClient(
+            {"compose.one": {"composeId": "c1", "domains": [{"domainId": "d1", "host": "x.example.com", "port": 80}]}}
+        )
+        manager = _manager(
+            _manifest(
+                Resource(kind="domain", name="x.example.com", in_="compose:web", data={"host": "x.example.com", "port": 80})
+            ),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run()
+        assert manager.report.actions[0].action == "skip"
+        assert not any(c[1] in ("domain.create", "domain.update") for c in client.calls)
+
+    def test_parent_not_found(self):
+        """We expect an error when the parent service is not in the instance."""
+        client = FakeClient({})
+        manager = _manager(
+            _manifest(Resource(kind="domain", name="x.example.com", in_="compose:nope", data={"host": "x.example.com"})),
+            client,
+            [],
+        )
+        with pytest.raises(ValueError):
+            manager.run()
+
+    def test_ambiguous_parent(self):
+        """We expect an error when the parent service name is ambiguous."""
+        client = FakeClient({})
+        manager = _manager(
+            _manifest(Resource(kind="domain", name="x.example.com", in_="compose:web", data={"host": "x.example.com"})),
+            client,
+            [_service("compose", "web", "c1"), _service("compose", "web", "c2")],
+        )
+        with pytest.raises(ValueError):
+            manager.run()
+
+    def test_mount_uses_service_id(self):
+        """We expect mounts to address their parent via serviceId + serviceType."""
+        client = FakeClient({"compose.one": {"composeId": "c1", "mounts": []}})
+        manager = _manager(
+            _manifest(
+                Resource(kind="mount", name="rclone.conf", in_="compose:web", data={"filePath": "rclone.conf", "mountPath": "/"})
+            ),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run()
+        create = next(c for c in client.calls if c[1] == "mount.create")
+        body = create[2]["body"]
+        assert body["serviceId"] == "c1"
+        assert body["serviceType"] == "compose"
+
+    def test_dry_run_plans_create(self):
+        """We expect dry-run to record the action without calling the API."""
+        client = FakeClient({"compose.one": {"composeId": "c1", "domains": []}})
+        manager = _manager(
+            _manifest(Resource(kind="domain", name="x.example.com", in_="compose:web", data={"host": "x.example.com"})),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run(dry_run=True)
+        assert manager.report.actions[0].action == "create"
+        assert not any(c[1] == "domain.create" for c in client.calls)
+
+
+def test_service_kinds_include_compose_application_and_dbs():
+    """We expect the service kinds that can host leaf resources."""
+    assert {"compose", "application", "postgres", "mysql", "redis"} <= SERVICE_KINDS

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -158,17 +158,6 @@ class TestResourceManager:
         assert manager.report.actions[0].action == "skip"
         assert not any(c[1] in ("domain.create", "domain.update") for c in client.calls)
 
-    def test_parent_not_found(self):
-        """We expect an error when the parent service is not in the instance."""
-        client = FakeClient({})
-        manager = _manager(
-            _manifest(Resource(kind="domain", name="x.example.com", in_="compose:nope", data={"host": "x.example.com"})),
-            client,
-            [],
-        )
-        with pytest.raises(ValueError):
-            manager.run()
-
     def test_ambiguous_parent(self):
         """We expect an error when the parent service name is ambiguous."""
         client = FakeClient({})
@@ -181,7 +170,8 @@ class TestResourceManager:
             manager.run()
 
     def test_mount_uses_service_id(self):
-        """We expect mounts to address their parent via serviceId + serviceType."""
+        """We expect mounts to address their parent via serviceId + serviceType
+        and to route to the mounts entity."""
         client = FakeClient({"compose.one": {"composeId": "c1", "mounts": []}})
         manager = _manager(
             _manifest(
@@ -191,10 +181,90 @@ class TestResourceManager:
             [_service("compose", "web", "c1")],
         )
         manager.run()
-        create = next(c for c in client.calls if c[1] == "mount.create")
+        create = next(c for c in client.calls if c[1] == "mounts.create")
         body = create[2]["body"]
         assert body["serviceId"] == "c1"
         assert body["serviceType"] == "compose"
+
+    def test_port_parent_uses_application_id(self):
+        """We expect ports to address their parent with applicationId."""
+        client = FakeClient({"application.one": {"applicationId": "a1", "ports": []}})
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="port",
+                    name="8080",
+                    in_="application:api",
+                    data={"publishedPort": 8080, "targetPort": 80, "protocol": "tcp"},
+                )
+            ),
+            client,
+            [_service("application", "api", "a1")],
+        )
+        manager.run()
+        create = next(c for c in client.calls if c[1] == "port.create")
+        assert create[2]["body"]["applicationId"] == "a1"
+
+    def test_port_wrong_parent_rejected(self):
+        """We expect ports under a non-application parent to fail."""
+        client = FakeClient({})
+        manager = _manager(
+            _manifest(Resource(kind="port", name="8080", in_="compose:web", data={"publishedPort": 8080})),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        with pytest.raises(ValueError):
+            manager.run()
+
+    def test_ancestor_path_disambiguates(self):
+        """We expect ancestor segments to scope the parent lookup."""
+        client = FakeClient({"compose.one": {"composeId": "c1", "domains": []}})
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="domain",
+                    name="x.example.com",
+                    in_="project:media / environment:production / compose:web",
+                    data={"host": "x.example.com"},
+                )
+            ),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run()
+        assert manager.report.actions[0].action == "create"
+
+    def test_missing_field_triggers_update(self):
+        """We expect a desired field absent from the live record to be set."""
+        client = FakeClient(
+            {"compose.one": {"composeId": "c1", "domains": [{"domainId": "d1", "host": "x.example.com"}]}}
+        )
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="domain",
+                    name="x.example.com",
+                    in_="compose:web",
+                    data={"host": "x.example.com", "https": True},
+                )
+            ),
+            client,
+            [_service("compose", "web", "c1")],
+        )
+        manager.run()
+        assert manager.report.actions[0].action == "update"
+
+    def test_missing_parent_records_skip(self):
+        """We expect a missing parent to record a skip action, not abort."""
+        client = FakeClient({})
+        manager = _manager(
+            _manifest(Resource(kind="domain", name="x.example.com", in_="compose:nope", data={"host": "x.example.com"})),
+            client,
+            [],
+        )
+        manager.run()
+        assert manager.report.actions[0].action == "skip"
+        assert "not found" in manager.report.actions[0].details
 
     def test_dry_run_plans_create(self):
         """We expect dry-run to record the action without calling the API."""

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,88 @@
+"""Offline manifest validation tests (issue #50)."""
+
+from dokli.config import ConnectionConfig
+from dokli.manifest import Manifest, Resource
+from dokli.validate import validate_manifest
+
+SCHEMA = {
+    "paths": {
+        "/compose.one": {
+            "get": {"parameters": [{"name": "composeId", "in": "query", "required": True}]}
+        },
+        "/domain.create": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"host": {"type": "string"}, "composeId": {"type": "string"}},
+                                "required": ["host"],
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/domain.update": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"domainId": {"type": "string"}, "host": {"type": "string"}},
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+}
+
+
+def _connection(mocker) -> ConnectionConfig:
+    connection = ConnectionConfig(name="test-env", url="https://example.com", api_key_cmd="echo key")
+    mocker.patch("dokli.validate.APIClient", return_value=type("C", (), {"schema": SCHEMA})())
+    return connection
+
+
+def _manifest(*resources) -> Manifest:
+    return Manifest(connection="test", resources=list(resources))
+
+
+def test_valid_manifest(mocker):
+    """We expect a valid resource to produce no issues."""
+    manifest = _manifest(
+        Resource(kind="domain", name="x.example.com", in_="compose:web", data={"host": "x.example.com"})
+    )
+    assert validate_manifest(_connection(mocker), manifest) == []
+
+
+def test_unknown_kind(mocker):
+    """We expect an unknown kind to be flagged."""
+    manifest = _manifest(Resource(kind="nope", name="x", in_="compose:web", data={}))
+    issues = validate_manifest(_connection(mocker), manifest)
+    assert any("unknown kind" in issue for issue in issues)
+
+
+def test_unknown_field(mocker):
+    """We expect a field absent from the schema to be flagged."""
+    manifest = _manifest(Resource(kind="domain", name="x", in_="compose:web", data={"bogus": 1}))
+    issues = validate_manifest(_connection(mocker), manifest)
+    assert any("unknown field 'bogus'" in issue for issue in issues)
+
+
+def test_missing_in(mocker):
+    """We expect a resource without a parent to be flagged."""
+    manifest = _manifest(Resource(kind="domain", name="x", data={"host": "x"}))
+    issues = validate_manifest(_connection(mocker), manifest)
+    assert any("missing 'in:'" in issue for issue in issues)
+
+
+def test_unsupported_parent(mocker):
+    """We expect a non-service parent to be flagged."""
+    manifest = _manifest(Resource(kind="domain", name="x", in_="project:media", data={"host": "x"}))
+    issues = validate_manifest(_connection(mocker), manifest)
+    assert any("not supported yet" in issue for issue in issues)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -38,6 +38,64 @@ SCHEMA = {
                 }
             }
         },
+        "/mounts.create": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"filePath": {"type": "string"}, "mountPath": {"type": "string"}},
+                                "required": ["filePath", "mountPath"],
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/mounts.update": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"mountId": {"type": "string"}, "filePath": {"type": "string"}},
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/port.create": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"publishedPort": {"type": "number"}},
+                                "required": ["publishedPort"],
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/port.update": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"portId": {"type": "string"}, "publishedPort": {"type": "number"}},
+                            }
+                        }
+                    }
+                }
+            }
+        },
     }
 }
 
@@ -86,3 +144,18 @@ def test_unsupported_parent(mocker):
     manifest = _manifest(Resource(kind="domain", name="x", in_="project:media", data={"host": "x"}))
     issues = validate_manifest(_connection(mocker), manifest)
     assert any("not supported yet" in issue for issue in issues)
+
+
+def test_wrong_service_parent(mocker):
+    """We expect a port under a compose to be flagged (application-only)."""
+    manifest = _manifest(Resource(kind="port", name="8080", in_="compose:web", data={"publishedPort": 8080}))
+    issues = validate_manifest(_connection(mocker), manifest)
+    assert any("cannot hang off 'compose'" in issue for issue in issues)
+
+
+def test_mount_kind_valid(mocker):
+    """We expect the mount kind to resolve to the mounts entity."""
+    manifest = _manifest(
+        Resource(kind="mount", name="rclone.conf", in_="compose:web", data={"filePath": "rclone.conf", "mountPath": "/"})
+    )
+    assert validate_manifest(_connection(mocker), manifest) == []


### PR DESCRIPTION
Closes #50 (slice 1): generic leaf resources in the manifest, resolved
against the Dokploy schema (self-describing "Dokli as Code").

## What
- `Manifest.resources`: `kind` / `name` / `in: <parent path>` / `data`, with
  `in` aliased over the field's `__pydantic_extra__` slot.
- `dokli/report.py`: `ApplyAction`/`ApplyReport` extracted (kind is now a
  string) to break the apply <-> resources cycle.
- `dokli/resources.py`: curated maps (`MATCH_KEYS`, `ENTITY_NAMES`,
  `PARENT_ID_FIELDS`, `PARENT_KINDS`, `SERVICE_KINDS`) over the schema
  conventions; `ResourceManager` plans/creates/updates/skips child records;
  secret refs (`{cmd}`/`{keyring}`) resolved in `data`; `in:` ancestor
  segments scope the parent lookup.
- `dokli validate`: offline validation of kinds, fields, parents and match
  keys against the connection's schema (warm cache).
- `dokli/apply.py`: re-captures state after the typed apply so resources
  attach to freshly created services; records a `skip` (not a crash) when the
  parent service is missing.

## Verified
- Unit: 208 tests pass; `make lint` clean.
- E2E on meche: `dokli-e2e` project (compose + domain, app + port) applied
  via `resources:`; `plan` idempotent ("No changes."); fully cleaned up.

## Follow-ups (separate issues)
- `export` of generic children; coverage for security/redirects/schedule/
  backup/mount kinds; multi-file `-f dir/` manifests; `--prune` (#49).