### PR TITLE
DOKLI-55-f1: generic resources round-trip (remaining kinds + export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokpl
 | `dokli plan [-f dokploy.yaml]` | Preview what would change. |
 | `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy]` | Configure the instance to match the manifest. `--dry-run` only previews; `--deploy` also triggers deployments. |
 | `dokli validate [-f dokploy.yaml]` | Validate the manifest offline against the connection's schema. |
-| `dokli export [connection] [-o file] [--include-secrets]` | Reverse-engineer a live instance into a manifest. |
+| `dokli export [connection] [-o file] [--include-secrets]` | Reverse-engineer a live instance into a manifest, including generic `resources:`. |
 
 ### Manifest
 
@@ -280,7 +280,7 @@ resources:
       password: {keyring: app-web-admin}
 ```
 
-`apply` is additive here too: an existing resource is updated, a missing one is created, and nothing is ever deleted because it is absent from the manifest.
+`apply` is additive here too: an existing resource is updated, a missing one is created, and nothing is ever deleted because it is absent from the manifest. `dokli export` emits the instance's existing child records as `resources:` entries (match key included, ids and secrets omitted; backup destinations by name), so the manifest round-trips: `export` → edit → `apply`.
 
 ### Workflow
 

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -178,7 +178,9 @@ def export_command(
     """Export the live state of an instance into a manifest."""
     connection = _get_connection(connection_name)
     manifest, warnings = export_manifest(connection, include_secrets=include_secrets)
-    content = yaml.safe_dump(manifest.model_dump(mode="json", exclude_none=True), sort_keys=False)
+    content = yaml.safe_dump(
+        manifest.model_dump(mode="json", exclude_none=True, by_alias=True), sort_keys=False
+    )
     if output == "-":
         rprint(content)
     else:

--- a/dokli/export.py
+++ b/dokli/export.py
@@ -5,6 +5,7 @@ only carry metadata. The export returns warnings listing providers whose
 credentials must be re-provided (via ``token_cmd``) for ``apply`` to succeed.
 """
 
+from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.manifest import (
     ApplicationService,
@@ -15,7 +16,16 @@ from dokli.manifest import (
     GitSource,
     Manifest,
     ProjectDef,
+    Resource,
     Service,
+)
+from dokli.resources import (
+    EXPORT_FIELDS,
+    LIST_LOOKUP,
+    PARENT_KINDS,
+    SECRET_FIELDS,
+    child_array_key,
+    match_key,
 )
 from dokli.state import LiveService, State, collect_state
 
@@ -30,16 +40,95 @@ def export_manifest(connection: ConnectionConfig, include_secrets: bool = False)
     never exported.
     """
     state = collect_state(connection)
+    client = APIClient(connection)
     warnings: list[str] = []
 
     git_providers = _export_git_providers(state, warnings)
     projects = [_export_project(project, include_secrets, warnings) for project in state.projects]
 
+    destination_names = _destination_names(client)
+    resources = [
+        resource
+        for project in state.projects
+        for environment in project.environments
+        for service in environment.services
+        for resource in _export_service_resources(
+            client, project, environment, service, destination_names, warnings
+        )
+    ]
+
     return Manifest(
         connection=connection.name,
         git_providers=git_providers,
         projects=projects,
+        resources=resources,
     ), warnings
+
+
+def _destination_names(client: APIClient) -> dict[str, str]:
+    raw = client.request("GET", "destination.all", {}).json()
+    items = raw if isinstance(raw, list) else raw.get("items", [])
+    return {item["destinationId"]: item.get("name") or "" for item in items if item.get("destinationId")}
+
+
+def _export_service_resources(
+    client: APIClient,
+    project,
+    environment,
+    service: LiveService,
+    destination_names: dict[str, str],
+    warnings: list[str],
+) -> list[Resource]:
+    """Export the child records of a service as generic resources."""
+    resources: list[Resource] = []
+    in_path = _in_path(project, environment, service)
+    for kind, fields in EXPORT_FIELDS.items():
+        allowed = PARENT_KINDS.get(kind)
+        if allowed is not None and service.type not in allowed:
+            continue
+        for child in _fetch_children(client, service, kind):
+            data = {field: child[field] for field in fields if child.get(field) is not None}
+            if set(SECRET_FIELDS.get(kind) or ()) & set(child):
+                warnings.append(
+                    f"Secret fields of '{service.name}' {kind} were not exported. "
+                    "Re-add them to the manifest for apply."
+                )
+            if kind == "backup" and child.get("destinationId"):
+                name = destination_names.get(child["destinationId"])
+                if name:
+                    data["destination"] = name
+                elif child["destinationId"]:
+                    data["destinationId"] = child["destinationId"]
+            key = match_key(kind)
+            if key not in data:
+                continue
+            resources.append(
+                Resource(
+                    kind=kind,
+                    name=str(child.get(key) or ""),
+                    in_=in_path,
+                    data=data,
+                )
+            )
+    return resources
+
+
+def _fetch_children(client: APIClient, service: LiveService, kind: str) -> list[dict]:
+    lookup = LIST_LOOKUP.get(kind)
+    if lookup is not None:
+        route, id_param, type_param = lookup
+        raw = client.request("GET", route, {id_param: service.service_id, type_param: service.type}).json()
+        return raw if isinstance(raw, list) else raw.get("items", [])
+    record = client.request("GET", f"{service.type}.one", {f"{service.type}Id": service.service_id}).json()
+    return record.get(child_array_key(kind)) or []
+
+
+def _in_path(project, environment, service: LiveService) -> str:
+    segments = [f"project:{project.name}"]
+    if not environment.is_default and environment.name:
+        segments.append(f"environment:{environment.name}")
+    segments.append(f"{service.type}:{service.name}")
+    return " / ".join(segments)
 
 
 def _export_git_providers(state: State, warnings: list[str]) -> list[GitProvider]:

--- a/dokli/resources.py
+++ b/dokli/resources.py
@@ -53,6 +53,19 @@ PARENT_KINDS: dict[str, set[str] | None] = {
     "mount": None,
 }
 
+# Kinds whose update requires fields the create may not set; the live child
+# record is merged into the update payload so those fields are preserved.
+UPDATE_MERGE_KINDS = frozenset({"backup"})
+
+# Data fields that are resolved by name (never sent as-is), and how.
+NAMED_REFERENCES: dict[str, str] = {"backup": "destination"}
+
+# Kinds whose children are fetched via a list route (route, id param, type
+# param) instead of a nested array on the parent record.
+LIST_LOOKUP: dict[str, tuple[str, str, str]] = {
+    "schedule": ("schedule.list", "id", "scheduleType"),
+}
+
 # Child kind -> the nested array key on the parent service record.
 CHILD_ARRAY: dict[str, str] = {child: key for key, child in NESTED_CHILD_KEYS.items()}
 
@@ -188,11 +201,15 @@ class ResourceManager:
         record = self.client.request("GET", f"{parent_kind}.one", {f"{parent_kind}Id": service.service_id}).json()
         key = match_key(resource.kind)
         value = match_value(resource, key)
-        children = record.get(child_array_key(resource.kind)) or []
+        children = self._children(resource, parent_kind, service.service_id, record)
         child = next((c for c in children if str(c.get(key)) == value), None)
 
         parent_field = PARENT_ID_FIELDS.get(resource.kind, f"{parent_kind}Id")
         body = {**resolve_data(resource.data), parent_field: service.service_id}
+        # Named references (e.g. backups -> destination) are resolved to ids.
+        named_field = NAMED_REFERENCES.get(resource.kind)
+        if named_field in body:
+            body[f"{named_field}Id"] = self._resolve_named(named_field, str(body.pop(named_field)))
         # The match key only falls back to the resource name when the data omits
         # it; matching itself is string-based, but the payload keeps the data types.
         if key not in body:
@@ -209,8 +226,7 @@ class ResourceManager:
         elif self._changed(child, body):
             action = "update"
             if not dry_run:
-                entity_id = child[f"{entity}Id"]
-                update_body = {**body, f"{entity}Id": entity_id}
+                update_body = self._update_body(resource, child, body, entity)
                 self.client.request("POST", f"{entity}.update", {"body": update_body})
         else:
             action = "skip"
@@ -268,6 +284,47 @@ class ResourceManager:
                 if "default" in prop:
                     filled[field] = prop["default"]
         return filled
+
+    def _update_body(self, resource: Resource, child: dict, body: dict, entity: str) -> dict:
+        """Build an update payload, merging the live child for full-object kinds.
+
+        Kinds in ``UPDATE_MERGE_KINDS`` have required update fields that the
+        create may not set; the live record supplies them (body wins, ids are
+        re-added from the entity).
+        """
+        entity_id = child[f"{entity}Id"]
+        merged = {**body, f"{entity}Id": entity_id}
+        if resource.kind not in UPDATE_MERGE_KINDS:
+            return merged
+        live = {
+            key: value
+            for key, value in child.items()
+            if not key.endswith(("Id", "At"))
+        }
+        return {**live, **body, f"{entity}Id": entity_id}
+
+    def _children(self, resource: Resource, parent_kind: str, service_id: str, record: dict) -> list[dict]:
+        """Fetch the live children of a resource kind for a parent service."""
+        lookup = LIST_LOOKUP.get(resource.kind)
+        if lookup is not None:
+            route, id_param, type_param = lookup
+            raw = self.client.request("GET", route, {id_param: service_id, type_param: parent_kind}).json()
+            return raw if isinstance(raw, list) else raw.get("items", [])
+        return record.get(child_array_key(resource.kind)) or []
+
+    def _resolve_named(self, entity: str, name: str) -> str:
+        """Resolve a named reference (e.g. ``destination``) to its id."""
+        raw = self.client.request("GET", f"{entity}.all", {}).json()
+        items = raw if isinstance(raw, list) else raw.get("items", [])
+        matches = [item for item in items if str(item.get("name")) == name]
+        if not matches:
+            raise ValueError(f"{entity} '{name}' not found in the instance.")
+        if len(matches) > 1:
+            raise ValueError(f"Ambiguous {entity} '{name}'.")
+        entity_id = matches[0].get(f"{entity}Id")
+        if not entity_id:
+            raise ValueError(f"{entity} '{name}' has no id.")
+        return str(entity_id)
 
     def _coerce(self, kind: str, field: str, value: str) -> Any:
         """Coerce a fallback match value to the schema type when numeric."""

--- a/dokli/resources.py
+++ b/dokli/resources.py
@@ -66,6 +66,24 @@ LIST_LOOKUP: dict[str, tuple[str, str, str]] = {
     "schedule": ("schedule.list", "id", "scheduleType"),
 }
 
+# Child kinds exported as generic resources, and the fields emitted per kind
+# (ids, parent ids and read-only fields are never exported; secrets omitted).
+EXPORT_FIELDS: dict[str, set[str]] = {
+    "domain": {"host", "https", "path", "port", "domainType"},
+    "port": {"publishedPort", "targetPort", "protocol", "publishMode"},
+    "security": {"username"},
+    "redirects": {"regex", "replacement", "permanent"},
+    "mount": {"type", "mountPath", "filePath"},
+    "schedule": {"name", "cronExpression", "command", "enabled"},
+    "backup": {"schedule", "prefix", "database", "databaseType", "enabled", "keepLatestCount", "backupType"},
+}
+
+# Fields that are never exported (secrets), per kind.
+SECRET_FIELDS: dict[str, set[str]] = {
+    "security": {"password"},
+    "backup": {"metadata"},
+}
+
 # Child kind -> the nested array key on the parent service record.
 CHILD_ARRAY: dict[str, str] = {child: key for key, child in NESTED_CHILD_KEYS.items()}
 

--- a/dokli/validate.py
+++ b/dokli/validate.py
@@ -2,15 +2,17 @@
 
 from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
-from dokli.manifest import Manifest
+from dokli.manifest import Manifest, Resource
 from dokli.resources import (
     MATCH_KEYS,
+    NAMED_REFERENCES,
     PARENT_KINDS,
     SERVICE_KINDS,
     entity_name,
     parse_in,
 )
 from dokli.tui.engine import parse_spec
+from dokli.tui.engine.spec import EntityRegistry
 
 
 def validate_manifest(connection: ConnectionConfig, manifest: Manifest) -> list[str]:
@@ -18,40 +20,52 @@ def validate_manifest(connection: ConnectionConfig, manifest: Manifest) -> list[
 
     Returns a list of issues (empty when valid).
     """
-    issues = []
     registry = parse_spec(APIClient(connection).schema)
+    issues: list[str] = []
     for resource in manifest.resources:
-        label = f"{resource.kind}:{resource.name}"
-        entity = registry.get(entity_name(resource.kind))
-        if entity is None:
-            issues.append(f"resource {label}: unknown kind '{resource.kind}'.")
+        issues.extend(_validate_resource(resource, registry))
+    return issues
+
+
+def _validate_resource(resource: Resource, registry: EntityRegistry) -> list[str]:
+    """Validate a single generic resource against the entity registry."""
+    issues: list[str] = []
+    label = f"{resource.kind}:{resource.name}"
+    entity = registry.get(entity_name(resource.kind))
+    if entity is None:
+        return [f"resource {label}: unknown kind '{resource.kind}'."]
+    create = entity.get("create")
+    update = entity.get("update")
+    if create is None or update is None:
+        return [f"resource {label}: kind lacks create/update actions."]
+    create_schema = create.request_schema
+    props = set(create_schema.get("properties", {})) | set(update.request_schema.get("properties", {}))
+    key = MATCH_KEYS.get(resource.kind, "name")
+    if key not in props:
+        issues.append(f"resource {label}: match key '{key}' is not in the schema.")
+    for field in resource.data:
+        if field == NAMED_REFERENCES.get(resource.kind):
             continue
-        create = entity.get("create")
-        update = entity.get("update")
-        if create is None or update is None:
-            issues.append(f"resource {label}: kind lacks create/update actions.")
+        if field not in props:
+            issues.append(f"resource {label}: unknown field '{field}'.")
+    for field in create_schema.get("required", []):
+        if field in resource.data or field == key or field.endswith("Id"):
             continue
-        props = set(create.request_schema.get("properties", {})) | set(
-            update.request_schema.get("properties", {})
+        prop = create_schema.get("properties", {}).get(field, {})
+        if "default" not in prop:
+            issues.append(f"resource {label}: missing required field '{field}'.")
+    segments = parse_in(resource.in_)
+    if not segments:
+        issues.append(f"resource {label}: missing 'in:'.")
+        return issues
+    parent_kind, _ = segments[-1]
+    if parent_kind not in SERVICE_KINDS:
+        issues.append(f"resource {label}: parent '{parent_kind}' is not supported yet.")
+        return issues
+    allowed = PARENT_KINDS.get(resource.kind)
+    if allowed is not None and parent_kind not in allowed:
+        issues.append(
+            f"resource {label}: cannot hang off '{parent_kind}' "
+            f"(allowed: {', '.join(sorted(allowed))})."
         )
-        for field in resource.data:
-            if field not in props:
-                issues.append(f"resource {label}: unknown field '{field}'.")
-        key = MATCH_KEYS.get(resource.kind, "name")
-        if key not in props:
-            issues.append(f"resource {label}: match key '{key}' is not in the schema.")
-        segments = parse_in(resource.in_)
-        if not segments:
-            issues.append(f"resource {label}: missing 'in:'.")
-            continue
-        parent_kind, _ = segments[-1]
-        if parent_kind not in SERVICE_KINDS:
-            issues.append(f"resource {label}: parent '{parent_kind}' is not supported yet.")
-            continue
-        allowed = PARENT_KINDS.get(resource.kind)
-        if allowed is not None and parent_kind not in allowed:
-            issues.append(
-                f"resource {label}: cannot hang off '{parent_kind}' "
-                f"(allowed: {', '.join(sorted(allowed))})."
-            )
     return issues

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,9 +1,170 @@
 """Export tests."""
 
+import pytest
+
 from dokli.config import ConnectionConfig
 from dokli.export import export_manifest
 from dokli.manifest import ApplicationService, ComposeService, DatabaseService
 from dokli.state import LiveEnvironment, LiveGitProvider, LiveProject, LiveService, State
+
+
+class _NullClient:
+    """APIClient stand-in returning empty payloads (no resources exported)."""
+
+    def request(self, method, path, params):
+        class _Response:
+            def json(self):
+                return {}
+
+        return _Response()
+
+
+@pytest.fixture(autouse=True)
+def _no_network(mocker):
+    mocker.patch("dokli.export.APIClient", return_value=_NullClient())
+
+
+class _FakeClient:
+    """APIClient stand-in returning configured records."""
+
+    def __init__(self, records):
+        self.records = records
+
+    def request(self, method, path, params):
+        records = self.records
+
+        class _Response:
+            def json(self):
+                return records.get(path, {})
+
+        return _Response()
+
+
+class TestExportResources:
+    """Generic resource export tests (issue #55)."""
+
+    def test_exports_application_children(self, mocker):
+        """We expect nested child records to be exported as resources."""
+        mocker.patch(
+            "dokli.export.APIClient",
+            return_value=_FakeClient(
+                {
+                    "application.one": {
+                        "applicationId": "a1",
+                        "domains": [
+                            {"domainId": "d1", "host": "www.example.com", "https": True, "path": "/", "domainType": "application"}
+                        ],
+                        "ports": [{"portId": "p1", "publishedPort": 8080, "targetPort": 80, "protocol": "tcp", "publishMode": "ingress"}],
+                        "mounts": [{"mountId": "m1", "type": "bind", "mountPath": "/etc", "filePath": "rclone.conf"}],
+                        "security": [{"securityId": "s1", "username": "admin", "password": "secret"}],
+                        "redirects": [{"redirectId": "r1", "regex": "/old", "replacement": "/new", "permanent": False}],
+                    },
+                    "schedule.list": [
+                        {"scheduleId": "sc1", "name": "nightly", "cronExpression": "0 3 * * *", "command": "echo x", "enabled": True}
+                    ],
+                    "destination.all": [],
+                }
+            ),
+        )
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[_project_live("app", [_live_service("application", "web")])],
+            ),
+        )
+
+        manifest, warnings = export_manifest(_connection())
+
+        kinds = {r.kind: r for r in manifest.resources}
+        assert kinds["domain"].name == "www.example.com"
+        assert kinds["domain"].data["https"] is True
+        assert kinds["domain"].in_ == "project:app / application:web"
+        assert kinds["port"].data["publishedPort"] == 8080
+        assert kinds["mount"].data["type"] == "bind"
+        assert kinds["redirects"].data["replacement"] == "/new"
+        assert "password" not in kinds["security"].data
+        assert kinds["security"].data["username"] == "admin"
+        assert kinds["schedule"].data["cronExpression"] == "0 3 * * *"
+        assert any("Secret fields" in w for w in warnings)
+
+    def test_exports_backup_with_destination_name(self, mocker):
+        """We expect backup destinations to be exported by name."""
+        mocker.patch(
+            "dokli.export.APIClient",
+            return_value=_FakeClient(
+                {
+                    "postgres.one": {
+                        "postgresId": "pg1",
+                        "backups": [
+                            {
+                                "backupId": "b1",
+                                "schedule": "0 4 * * *",
+                                "prefix": "db",
+                                "database": "db",
+                                "databaseType": "postgres",
+                                "enabled": True,
+                                "destinationId": "dst1",
+                                "keepLatestCount": 7,
+                            }
+                        ],
+                    },
+                    "destination.all": [{"destinationId": "dst1", "name": "local-bucket"}],
+                }
+            ),
+        )
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(
+                connection="test-env",
+                projects=[_project_live("app", [_live_service("postgres", "db")])],
+            ),
+        )
+
+        manifest, _ = export_manifest(_connection())
+
+        backup = manifest.resources[0]
+        assert backup.kind == "backup"
+        assert backup.data["destination"] == "local-bucket"
+        assert "destinationId" not in backup.data
+
+    def test_non_default_environment_in_path(self, mocker):
+        """We expect named environments to appear in the in path."""
+        mocker.patch("dokli.export.APIClient", return_value=_NullClient())
+        project = LiveProject(
+            project_id="p1",
+            name="app",
+            environments=[
+                LiveEnvironment(
+                    environment_id="e1",
+                    name="staging",
+                    is_default=False,
+                    services=[_live_service("application", "web")],
+                )
+            ],
+        )
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(connection="test-env", projects=[project]),
+        )
+
+        manifest, _ = export_manifest(_connection())
+
+        assert manifest.resources == []
+
+    def test_round_trip_loads(self, mocker):
+        """We expect an exported manifest to load back with its resources."""
+        mocker.patch("dokli.export.APIClient", return_value=_NullClient())
+        mocker.patch(
+            "dokli.export.collect_state",
+            return_value=State(connection="test-env", projects=[]),
+        )
+
+        manifest, _ = export_manifest(_connection())
+        reloaded = manifest.__class__.model_validate(manifest.model_dump(by_alias=True))
+
+        assert reloaded.resources == manifest.resources
+        assert reloaded.connection == "test-env"
 
 
 def _connection() -> ConnectionConfig:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -266,6 +266,52 @@ class TestResourceManager:
         assert manager.report.actions[0].action == "skip"
         assert "not found" in manager.report.actions[0].details
 
+    def test_schedule_lists_via_list_route(self):
+        """We expect schedules to be fetched via schedule.list, not a nested array."""
+        client = FakeClient(
+            {
+                "application.one": {"applicationId": "a1"},
+                "schedule.list": [
+                    {"scheduleId": "s1", "name": "nightly", "cronExpression": "0 3 * * *", "command": "echo x"}
+                ],
+            }
+        )
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="schedule",
+                    name="nightly",
+                    in_="application:api",
+                    data={"name": "nightly", "cronExpression": "0 3 * * *", "command": "echo x"},
+                )
+            ),
+            client,
+            [_service("application", "api", "a1")],
+        )
+        manager.run()
+        assert manager.report.actions[0].action == "skip"
+        call = next(c for c in client.calls if c[1] == "schedule.list")
+        assert call[2] == {"id": "a1", "scheduleType": "application"}
+
+    def test_schedule_created_when_missing(self):
+        """We expect a missing schedule to be created with its parent id."""
+        client = FakeClient({"application.one": {"applicationId": "a1"}, "schedule.list": []})
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="schedule",
+                    name="nightly",
+                    in_="application:api",
+                    data={"name": "nightly", "cronExpression": "0 3 * * *", "command": "echo x"},
+                )
+            ),
+            client,
+            [_service("application", "api", "a1")],
+        )
+        manager.run()
+        create = next(c for c in client.calls if c[1] == "schedule.create")
+        assert create[2]["body"]["applicationId"] == "a1"
+
     def test_dry_run_plans_create(self):
         """We expect dry-run to record the action without calling the API."""
         client = FakeClient({"compose.one": {"composeId": "c1", "domains": []}})
@@ -277,6 +323,98 @@ class TestResourceManager:
         manager.run(dry_run=True)
         assert manager.report.actions[0].action == "create"
         assert not any(c[1] == "domain.create" for c in client.calls)
+
+    def test_backup_resolves_destination_by_name(self):
+        """We expect a backup destination to be resolved from destination.all."""
+        client = FakeClient(
+            {
+                "postgres.one": {"postgresId": "pg1", "backups": []},
+                "destination.all": [{"destinationId": "dst1", "name": "local-bucket"}],
+            }
+        )
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="backup",
+                    name="daily",
+                    in_="postgres:db",
+                    data={"destination": "local-bucket", "schedule": "0 3 * * *", "prefix": "db", "database": "db"},
+                )
+            ),
+            client,
+            [_service("postgres", "db", "pg1")],
+        )
+        manager.run()
+        create = next(c for c in client.calls if c[1] == "backup.create")
+        assert create[2]["body"]["destinationId"] == "dst1"
+        assert "destination" not in create[2]["body"]
+        assert create[2]["body"]["postgresId"] == "pg1"
+
+    def test_backup_unknown_destination_raises(self):
+        """We expect an unknown backup destination to abort."""
+        client = FakeClient(
+            {
+                "postgres.one": {"postgresId": "pg1", "backups": []},
+                "destination.all": [],
+            }
+        )
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="backup",
+                    name="daily",
+                    in_="postgres:db",
+                    data={"destination": "nope", "schedule": "0 3 * * *", "prefix": "db", "database": "db"},
+                )
+            ),
+            client,
+            [_service("postgres", "db", "pg1")],
+        )
+        with pytest.raises(ValueError):
+            manager.run()
+
+    def test_backup_update_merges_live_fields(self):
+        """We expect backup updates to merge live fields the create may not set."""
+        client = FakeClient(
+            {
+                "postgres.one": {
+                    "postgresId": "pg1",
+                    "backups": [
+                        {
+                            "backupId": "b1",
+                            "schedule": "0 3 * * *",
+                            "enabled": True,
+                            "prefix": "db",
+                            "destinationId": "dst1",
+                            "database": "db",
+                            "keepLatestCount": 7,
+                            "serviceName": "db",
+                            "metadata": None,
+                        }
+                    ],
+                },
+                "destination.all": [{"destinationId": "dst1", "name": "local-bucket"}],
+            }
+        )
+        manager = _manager(
+            _manifest(
+                Resource(
+                    kind="backup",
+                    name="daily",
+                    in_="postgres:db",
+                    data={"destination": "local-bucket", "schedule": "0 3 * * *", "prefix": "db2", "database": "db"},
+                )
+            ),
+            client,
+            [_service("postgres", "db", "pg1")],
+        )
+        manager.run()
+        update = next(c for c in client.calls if c[1] == "backup.update")
+        body = update[2]["body"]
+        assert body["prefix"] == "db2"
+        assert body["enabled"] is True
+        assert body["keepLatestCount"] == 7
+        assert body["backupId"] == "b1"
 
 
 def test_service_kinds_include_compose_application_and_dbs():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -45,8 +45,12 @@ SCHEMA = {
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "properties": {"filePath": {"type": "string"}, "mountPath": {"type": "string"}},
-                                "required": ["filePath", "mountPath"],
+                                "properties": {
+                                    "type": {"type": "string", "enum": ["bind", "volume", "file"]},
+                                    "filePath": {"type": "string"},
+                                    "mountPath": {"type": "string"},
+                                },
+                                "required": ["type", "filePath", "mountPath"],
                             }
                         }
                     }
@@ -156,6 +160,20 @@ def test_wrong_service_parent(mocker):
 def test_mount_kind_valid(mocker):
     """We expect the mount kind to resolve to the mounts entity."""
     manifest = _manifest(
-        Resource(kind="mount", name="rclone.conf", in_="compose:web", data={"filePath": "rclone.conf", "mountPath": "/"})
+        Resource(
+            kind="mount",
+            name="rclone.conf",
+            in_="compose:web",
+            data={"type": "bind", "filePath": "rclone.conf", "mountPath": "/"},
+        )
     )
     assert validate_manifest(_connection(mocker), manifest) == []
+
+
+def test_mount_missing_required_type(mocker):
+    """We expect a mount without its required type field to be flagged."""
+    manifest = _manifest(
+        Resource(kind="mount", name="rclone.conf", in_="compose:web", data={"filePath": "rclone.conf", "mountPath": "/"})
+    )
+    issues = validate_manifest(_connection(mocker), manifest)
+    assert any("missing required field 'type'" in issue for issue in issues)


### PR DESCRIPTION
Closes #56 and #55: the remaining child kinds are applied generically, and
`dokli export` emits child records as `resources:` so the manifest round-trips.

## Apply (resources)
- **schedule** now resolves via `schedule.list?scheduleType&id` (they are not a
  nested array on the parent record).
- **backup**: `data.destination: <name>` resolves against `destination.all`
  (named reference, `NAMED_REFERENCES`); updates merge the live record
  (`UPDATE_MERGE_KINDS`) because `backup.update` requires fields `create` does
  not set.
- **validate** flags required create fields missing from `data` (e.g. mount
  `type`, security `password`) and understands named references.

## Export
- Emits `resources:` for nested kinds (domain/port/mount/security/redirects/
  backup) plus list kinds (schedule), with curated per-kind field whitelists
  (`EXPORT_FIELDS`), secret redaction (`SECRET_FIELDS`) and backup destinations
  exported by name.
- `in:` paths include `project:` + optional `environment:` ancestors.
- Manifest serialization now uses `by_alias=True`, so `apiVersion`/`in` are
  written correctly (bug fixed).

## Verified
- 218 tests; `make lint` clean.
- E2E on meche: security/redirects/schedule/mount/backup applied and idempotent
  (`skip` on re-apply), cleaned up.
- Round-trip: `dokli export meche` → `dokli validate` reports "Manifest is
  valid."
