### PR TITLE
DOKLI-57-f1: multi-file manifests (-f dir/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokpl
 | `dokli init` | Scaffold a new manifest. |
 | `dokli refresh [connection]` | Refetch and refresh the cached OpenAPI schema for a connection. |
 | `dokli state [connection]` | Show the current state of an instance. |
-| `dokli plan [-f dokploy.yaml]` | Preview what would change. |
+| `dokli plan [-f dokploy.yaml]` | Preview what would change. `-f` also accepts a directory (every `*.yaml`/`*.yml` in it). |
 | `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy]` | Configure the instance to match the manifest. `--dry-run` only previews; `--deploy` also triggers deployments. |
 | `dokli validate [-f dokploy.yaml]` | Validate the manifest offline against the connection's schema. |
 | `dokli export [connection] [-o file] [--include-secrets]` | Reverse-engineer a live instance into a manifest, including generic `resources:`. |
@@ -290,6 +290,9 @@ dokli plan                           # preview changes
 dokli apply --dry-run                # dry run
 dokli apply                          # configure the instance
 ```
+
+`-f` accepts a directory: `apply`/`plan`/`validate` then process every
+`*.yaml`/`*.yml` in it (sorted), one report per manifest.
 
 ## TUI
 

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -15,7 +15,7 @@ from dokli.diff import build_plan
 from dokli.export import export_manifest
 from dokli.formatting import redact_secrets
 from dokli.init import init_manifest
-from dokli.manifest import Manifest
+from dokli.manifest import load_manifests
 from dokli.openapi_cli import build_command as build_api_command
 from dokli.report import ApplyReport
 from dokli.secrets_cli import build_command as build_secrets_command
@@ -101,26 +101,34 @@ def state_command(
 
 @app.command(name="plan")
 def plan_command(
-    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to a manifest file or directory."),
 ) -> None:
-    """Show what would change between the manifest and the live instance."""
-    manifest = Manifest.load(manifest_file)
-    connection = _get_connection(manifest.connection)
-    live_state = collect_state(connection)
-    plan = build_plan(manifest, live_state)
-    if not plan.has_changes:
+    """Show what would change between the manifest(s) and the live instances."""
+    manifests = load_manifests(manifest_file)
+    if not manifests:
+        raise typer.BadParameter(f"No manifests found in '{manifest_file}'.")
+    changed = False
+    for manifest in manifests:
+        connection = _get_connection(manifest.connection)
+        live_state = collect_state(connection)
+        plan = build_plan(manifest, live_state)
+        if not plan.has_changes:
+            continue
+        changed = True
+        if len(manifests) > 1:
+            rprint(f"[bold]{manifest.connection}[/bold]")
+        table = Table(title=f"Plan for {manifest.connection}")
+        table.add_column("Action")
+        table.add_column("Kind")
+        table.add_column("Project")
+        table.add_column("Name")
+        table.add_column("Details")
+        for item in plan.items:
+            details = ", ".join(item.changed) if item.changed else item.reason
+            table.add_row(item.action, item.kind, item.project, item.name, details)
+        rprint(table)
+    if not changed:
         rprint("[green]No changes.[/green]")
-        return
-    table = Table(title=f"Plan for {manifest.connection}")
-    table.add_column("Action")
-    table.add_column("Kind")
-    table.add_column("Project")
-    table.add_column("Name")
-    table.add_column("Details")
-    for item in plan.items:
-        details = ", ".join(item.changed) if item.changed else item.reason
-        table.add_row(item.action, item.kind, item.project, item.name, details)
-    rprint(table)
 
 
 def _print_apply_report(report: ApplyReport) -> None:
@@ -142,31 +150,42 @@ def _print_apply_report(report: ApplyReport) -> None:
 
 @app.command(name="apply")
 def apply_command(
-    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to a manifest file or directory."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would change without applying."),
     deploy: bool = typer.Option(False, "--deploy", help="Deploy services after applying."),
 ) -> None:
-    """Apply the manifest to a Dokploy instance (idempotent, additive)."""
-    manifest = Manifest.load(manifest_file)
-    connection = _get_connection(manifest.connection)
-    applier = Applier(manifest, connection, deploy=deploy)
-    report = applier.run(dry_run=dry_run)
-    _print_apply_report(report)
+    """Apply a manifest (or every manifest in a directory) to Dokploy instances."""
+    manifests = load_manifests(manifest_file)
+    if not manifests:
+        raise typer.BadParameter(f"No manifests found in '{manifest_file}'.")
+    for manifest in manifests:
+        connection = _get_connection(manifest.connection)
+        applier = Applier(manifest, connection, deploy=deploy)
+        report = applier.run(dry_run=dry_run)
+        if len(manifests) > 1:
+            rprint(f"[bold]{manifest_file} ({manifest.connection})[/bold]")
+        _print_apply_report(report)
 
 
 @app.command(name="validate")
 def validate_command(
-    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+    manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to a manifest file or directory."),
 ) -> None:
-    """Validate a manifest offline against the connection's schema."""
-    manifest = Manifest.load(manifest_file)
-    connection = _get_connection(manifest.connection)
-    issues = validate_manifest(connection, manifest)
-    if issues:
-        for issue in issues:
+    """Validate a manifest (or every manifest in a directory) offline."""
+    manifests = load_manifests(manifest_file)
+    if not manifests:
+        raise typer.BadParameter(f"No manifests found in '{manifest_file}'.")
+    all_issues: list[str] = []
+    for manifest in manifests:
+        connection = _get_connection(manifest.connection)
+        issues = validate_manifest(connection, manifest)
+        if issues:
+            all_issues.extend(f"[{manifest.connection}] {issue}" for issue in issues)
+    if all_issues:
+        for issue in all_issues:
             rprint(f"[yellow]{issue}[/yellow]")
         raise typer.Exit(code=1)
-    rprint("[green]Manifest is valid.[/green]")
+    rprint("[green]Manifests are valid.[/green]")
 
 
 @app.command(name="export")

--- a/dokli/manifest.py
+++ b/dokli/manifest.py
@@ -4,6 +4,7 @@ The manifest (``dokploy.yaml``) describes the desired state of a Dokploy
 instance. See :issue:`20` and :issue:`50`.
 """
 
+from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import yaml
@@ -198,3 +199,12 @@ class Manifest(BaseModel):
         if api_version != "v1":
             raise ValueError(f"Unsupported manifest apiVersion '{api_version}' (expected 'v1').")
         return cls.model_validate(data)
+
+
+def load_manifests(path: str) -> list[Manifest]:
+    """Load one manifest (file) or every ``*.yaml``/``*.yml`` in a directory."""
+    target = Path(path)
+    if not target.is_dir():
+        return [Manifest.load(str(target))]
+    files = sorted({*(target.glob("*.yaml")), *(target.glob("*.yml"))})
+    return [Manifest.load(str(file)) for file in files]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,7 +3,7 @@
 import pytest
 import yaml
 
-from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Resource
+from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Resource, load_manifests
 
 
 def _load_manifest(raw_yaml: str) -> Manifest:
@@ -43,6 +43,29 @@ class TestResource:
         target.write_text("apiVersion: v2\nconnection: prod\n")
         with pytest.raises(ValueError):
             Manifest.load(str(target))
+
+
+class TestLoadManifests:
+    """Multi-manifest loading (issue #57)."""
+
+    def test_loads_single_file(self, tmp_path):
+        """We expect a file path to load as a single manifest."""
+        target = tmp_path / "dokploy.yaml"
+        target.write_text("connection: prod\nprojects: []\n")
+        manifests = load_manifests(str(target))
+        assert [m.connection for m in manifests] == ["prod"]
+
+    def test_loads_all_yaml_in_directory_sorted(self, tmp_path):
+        """We expect every yaml in a directory to be loaded, sorted."""
+        (tmp_path / "b.yaml").write_text("connection: beta\nprojects: []\n")
+        (tmp_path / "a.yaml").write_text("connection: alpha\nprojects: []\n")
+        (tmp_path / "notes.txt").write_text("not a manifest")
+        manifests = load_manifests(str(tmp_path))
+        assert [m.connection for m in manifests] == ["alpha", "beta"]
+
+    def test_empty_directory(self, tmp_path):
+        """We expect an empty directory to yield no manifests."""
+        assert load_manifests(str(tmp_path)) == []
 
 
 class TestManifest:


### PR DESCRIPTION
Closes #57: `apply`/`plan`/`validate` accept a directory with `-f`, processing
every `*.yaml`/`*.yml` in it (sorted), one report per manifest.

- `load_manifests(path)`: file → single manifest; directory → all manifests
  sorted; empty dir → error ("No manifests found").
- `apply` runs each manifest sequentially (each with its own connection),
  labeling reports when multiple.
- `plan` prints per-manifest tables only for manifests with changes.
- `validate` aggregates issues across manifests, prefixed by connection.
- README documents directory support.

221 tests; `make lint` clean. Verified against meche: `validate` + `apply
--dry-run` on a two-manifest directory.
