### PR TITLE
DOKLI-49-f1: apply --prune (destructive reconciliation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ $ dokli api test-env project one --format json zuanf1SWHMFO11y6xqpRR
 
 ## Dokli as Code
 
-Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokploy. A manifest file (`dokploy.yaml`) describes the desired state and `dokli apply` brings the instance to match it — idempotent and additive (it never deletes resources that are not in the manifest).
+Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokploy. A manifest file (`dokploy.yaml`) describes the desired state and `dokli apply` brings the instance to match it — idempotent and additive (it never deletes resources that are not in the manifest, unless you pass `--prune`).
 
 ### Commands
 
@@ -183,10 +183,12 @@ Dokli can manage a Dokploy instance declaratively, like Docker Compose for Dokpl
 | `dokli init` | Scaffold a new manifest. |
 | `dokli refresh [connection]` | Refetch and refresh the cached OpenAPI schema for a connection. |
 | `dokli state [connection]` | Show the current state of an instance. |
-| `dokli plan [-f dokploy.yaml]` | Preview what would change. |
-| `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy]` | Configure the instance to match the manifest. `--dry-run` only previews; `--deploy` also triggers deployments. |
+| `dokli plan [-f dokploy.yaml] [--prune]` | Preview what would change. `--prune` also plans deletions. |
+| `dokli apply [-f dokploy.yaml] [--dry-run] [--deploy] [--prune]` | Configure the instance to match the manifest. `--dry-run` only previews; `--deploy` also triggers deployments. |
 | `dokli validate [-f dokploy.yaml]` | Validate the manifest offline against the connection's schema. |
 | `dokli export [connection] [-o file] [--include-secrets]` | Reverse-engineer a live instance into a manifest, including generic `resources:`. |
+
+**`--prune`** (destructive): deletes child records and services that exist in the instance but are not described in the manifest — scoped to projects *declared* in the manifest; projects and environments absent from it are never touched. Always preview with `dokli plan --prune` first.
 
 ### Manifest
 

--- a/dokli/apply.py
+++ b/dokli/apply.py
@@ -13,8 +13,9 @@ from dokli.api_client import APIClient
 from dokli.config import ConnectionConfig
 from dokli.diff import resolve_compose_file
 from dokli.manifest import ApplicationService, ComposeService, DatabaseService, Manifest, Service
+from dokli.prune import Pruner
 from dokli.report import ApplyAction, ApplyReport
-from dokli.resources import ResourceManager
+from dokli.resources import ResourceManager, build_registry
 from dokli.secrets import db_account, get_secret
 from dokli.state import LiveGitProvider, LiveProject, LiveService, State, collect_state
 
@@ -32,8 +33,8 @@ class Applier:
         self._live_providers: dict[str, LiveGitProvider] = {}
         self._state: State = State(connection="")
 
-    def run(self, dry_run: bool = False) -> ApplyReport:
-        """Apply the manifest, optionally only planning (dry_run)."""
+    def run(self, dry_run: bool = False, prune: bool = False) -> ApplyReport:
+        """Apply the manifest, optionally only planning (dry_run) or pruning."""
         state = collect_state(self.connection, client=self.client)
         self._state = state
         self._live_providers = {provider.name: provider for provider in state.git_providers}
@@ -49,9 +50,12 @@ class Applier:
 
         # Re-capture the state so generic resources can attach to services that
         # were just created by the typed apply above.
-        if self.manifest.resources:
+        if self.manifest.resources or prune:
             self._state = collect_state(self.connection, client=self.client)
-            ResourceManager(self).run(dry_run)
+            if self.manifest.resources:
+                ResourceManager(self).run(dry_run)
+            if prune:
+                Pruner(self, build_registry(self.client)).run(dry_run)
 
         return self.report
 

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -102,10 +102,17 @@ def state_command(
 @app.command(name="plan")
 def plan_command(
     manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
+    prune: bool = typer.Option(
+        False, "--prune", help="Also plan deletions of resources/services not in the manifest."
+    ),
 ) -> None:
     """Show what would change between the manifest and the live instance."""
     manifest = Manifest.load(manifest_file)
     connection = _get_connection(manifest.connection)
+    if prune:
+        report = Applier(manifest, connection).run(dry_run=True, prune=True)
+        _print_apply_report(report)
+        return
     live_state = collect_state(connection)
     plan = build_plan(manifest, live_state)
     if not plan.has_changes:
@@ -145,12 +152,17 @@ def apply_command(
     manifest_file: str = typer.Option("dokploy.yaml", "--file", "-f", help="Path to the manifest."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would change without applying."),
     deploy: bool = typer.Option(False, "--deploy", help="Deploy services after applying."),
+    prune: bool = typer.Option(
+        False,
+        "--prune",
+        help="Delete resources/services not in the manifest (within declared projects).",
+    ),
 ) -> None:
-    """Apply the manifest to a Dokploy instance (idempotent, additive)."""
+    """Apply the manifest to a Dokploy instance (idempotent, additive; --prune deletes)."""
     manifest = Manifest.load(manifest_file)
     connection = _get_connection(manifest.connection)
     applier = Applier(manifest, connection, deploy=deploy)
-    report = applier.run(dry_run=dry_run)
+    report = applier.run(dry_run=dry_run, prune=prune)
     _print_apply_report(report)
 
 

--- a/dokli/prune.py
+++ b/dokli/prune.py
@@ -1,0 +1,124 @@
+"""Destructive reconciliation (issue #49).
+
+``apply --prune`` deletes, within projects declared in the manifest, any child
+record or service that is not described there. Projects and environments not in
+the manifest are never touched.
+"""
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from dokli.report import ApplyAction
+from dokli.resources import (
+    EXPORT_FIELDS,
+    PARENT_KINDS,
+    ResourceManager,
+    delete_spec,
+    fetch_children,
+    match_key,
+    match_value,
+    parse_in,
+)
+
+if TYPE_CHECKING:
+    from dokli.manifest import Manifest
+
+from dokli.tui.engine.spec import EntityRegistry
+
+
+class Pruner:
+    """Deletes live resources/services not described in the manifest."""
+
+    def __init__(self, applier, registry: EntityRegistry) -> None:
+        """Construct the pruner sharing the applier's client/report/state."""
+        self.applier = applier
+        self.client = applier.client
+        self.manifest: Manifest = applier.manifest
+        self.report = applier.report
+        self.state = applier._state
+        self.registry = registry
+        self._resource_manager = ResourceManager(applier)
+        self._desired_children: dict[tuple[str, str], set[str]] = defaultdict(set)
+
+    def run(self, dry_run: bool = False) -> None:
+        """Record delete actions for resources/services not in the manifest."""
+        self._index_desired_children()
+        for project_def in self.manifest.projects:
+            live_project = next((p for p in self.state.projects if p.name == project_def.name), None)
+            if live_project is None:
+                continue
+            self._prune_project(project_def, live_project, dry_run)
+
+    def _index_desired_children(self) -> None:
+        """Map (service id, kind) -> set of desired match values from resources."""
+        for resource in self.manifest.resources:
+            segments = parse_in(resource.in_)
+            if not segments:
+                continue
+            parent_kind, parent_name = segments[-1]
+            service = self._resource_manager._find_live_service(parent_kind, parent_name, segments[:-1])
+            if service is None:
+                continue
+            key = match_key(resource.kind)
+            self._desired_children[(service.service_id, resource.kind)].add(match_value(resource, key))
+
+    def _prune_project(self, project_def, live_project, dry_run: bool) -> None:
+        default_environment = next((e for e in live_project.environments if e.is_default), None)
+        if default_environment is not None:
+            desired = {service.name for service in project_def.services}
+            for service in default_environment.services:
+                if service.name not in desired:
+                    self._delete_service(service, dry_run)
+            for service_def in project_def.services:
+                live = next((s for s in default_environment.services if s.name == service_def.name), None)
+                if live is not None:
+                    self._prune_service_children(live, dry_run)
+        for environment_def in project_def.environments:
+            live_environment = next((e for e in live_project.environments if e.name == environment_def.name), None)
+            if live_environment is None:
+                continue
+            desired = {service.name for service in environment_def.services}
+            for service in live_environment.services:
+                if service.name not in desired:
+                    self._delete_service(service, dry_run)
+            for service_def in environment_def.services:
+                live = next((s for s in live_environment.services if s.name == service_def.name), None)
+                if live is not None:
+                    self._prune_service_children(live, dry_run)
+
+    def _prune_service_children(self, live_service, dry_run: bool) -> None:
+        record = self.client.request(
+            "GET", f"{live_service.type}.one", {f"{live_service.type}Id": live_service.service_id}
+        ).json()
+        for kind in EXPORT_FIELDS:
+            allowed = PARENT_KINDS.get(kind)
+            if allowed is not None and live_service.type not in allowed:
+                continue
+            desired = self._desired_children[(live_service.service_id, kind)]
+            key = match_key(kind)
+            for child in fetch_children(self.client, kind, live_service.type, live_service.service_id, record):
+                if str(child.get(key)) in desired:
+                    continue
+                self._delete(kind, child, dry_run, label=child.get(key))
+
+    def _delete_service(self, live_service, dry_run: bool) -> None:
+        self._delete(
+            live_service.type,
+            {f"{live_service.type}Id": live_service.service_id},
+            dry_run,
+            label=live_service.name,
+        )
+
+    def _delete(self, kind: str, record: dict, dry_run: bool, label: Any = None) -> None:
+        spec = delete_spec(self.registry, kind)
+        if spec is None:
+            self.report.actions.append(
+                ApplyAction(action="skip", kind=kind, name="", details=f"No delete route for '{kind}'.")
+            )
+            return
+        route, id_field, defaults = spec
+        name = str(label or record.get("name") or record.get(id_field) or "")
+        self.report.actions.append(ApplyAction(action="delete", kind=kind, name=name))
+        if not dry_run:
+            body = {**defaults, id_field: record[id_field]}
+            self.client.request("POST", route, {"body": body})

--- a/dokli/report.py
+++ b/dokli/report.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 class ApplyAction(BaseModel):
     """A single apply action."""
 
-    action: Literal["create", "update", "validate", "skip"]
+    action: Literal["create", "update", "validate", "delete", "skip"]
     kind: str
     project: str = ""
     name: str

--- a/dokli/resources.py
+++ b/dokli/resources.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 from dokli.manifest import Resource
 from dokli.report import ApplyAction
 from dokli.tui.engine import parse_spec
-from dokli.tui.engine.spec import NESTED_CHILD_KEYS
+from dokli.tui.engine.spec import NESTED_CHILD_KEYS, EntityRegistry
 
 if TYPE_CHECKING:
     from dokli.state import State
@@ -83,6 +83,53 @@ SECRET_FIELDS: dict[str, set[str]] = {
     "security": {"password"},
     "backup": {"metadata"},
 }
+
+# Extra required fields for delete routes that have no schema default.
+DELETE_DEFAULTS: dict[str, dict[str, Any]] = {"compose": {"deleteVolumes": False}}
+
+
+def build_registry(client) -> EntityRegistry:
+    """Parse the client's schema into an entity registry (empty if unavailable)."""
+    schema = getattr(client, "schema", None)
+    return parse_spec(schema) if isinstance(schema, dict) else EntityRegistry()
+
+
+def fetch_children(client, kind: str, parent_kind: str, service_id: str, parent_record: dict) -> list[dict]:
+    """Fetch the live children of a resource kind for a parent service."""
+    lookup = LIST_LOOKUP.get(kind)
+    if lookup is not None:
+        route, id_param, type_param = lookup
+        raw = client.request("GET", route, {id_param: service_id, type_param: parent_kind}).json()
+        return raw if isinstance(raw, list) else raw.get("items", [])
+    return parent_record.get(child_array_key(kind)) or []
+
+
+def delete_spec(registry, kind: str) -> tuple[str, str, dict] | None:
+    """The delete route, id field and required defaults for a kind.
+
+    Derived from the entity's destructive actions (``delete``/``remove``) plus
+    curated defaults for required fields without a schema default.
+    """
+    entity = entity_name(kind)
+    spec = registry.get(entity)
+    if spec is None:
+        return None
+    for verb in ("delete", "remove"):
+        action = spec.get(verb)
+        if action is None:
+            continue
+        schema = action.request_schema
+        required = schema.get("required", [])
+        id_field = next((field for field in required if field.endswith("Id")), f"{entity}Id")
+        defaults = dict(DELETE_DEFAULTS.get(kind, {}))
+        for field in required:
+            if field.endswith("Id") or field in defaults:
+                continue
+            prop = schema.get("properties", {}).get(field, {})
+            if "default" in prop:
+                defaults[field] = prop["default"]
+        return f"{entity}.{verb}", id_field, defaults
+    return None
 
 # Child kind -> the nested array key on the parent service record.
 CHILD_ARRAY: dict[str, str] = {child: key for key, child in NESTED_CHILD_KEYS.items()}
@@ -171,8 +218,7 @@ class ResourceManager:
         self.client = applier.client
         self.report = applier.report
         self.state: State = applier._state
-        schema = getattr(self.client, "schema", None)
-        self.registry = parse_spec(schema) if isinstance(schema, dict) else {}
+        self.registry = build_registry(self.client)
 
     def run(self, dry_run: bool = False) -> None:
         """Apply all generic resources."""
@@ -219,7 +265,7 @@ class ResourceManager:
         record = self.client.request("GET", f"{parent_kind}.one", {f"{parent_kind}Id": service.service_id}).json()
         key = match_key(resource.kind)
         value = match_value(resource, key)
-        children = self._children(resource, parent_kind, service.service_id, record)
+        children = fetch_children(self.client, resource.kind, parent_kind, service.service_id, record)
         child = next((c for c in children if str(c.get(key)) == value), None)
 
         parent_field = PARENT_ID_FIELDS.get(resource.kind, f"{parent_kind}Id")
@@ -320,15 +366,6 @@ class ResourceManager:
             if not key.endswith(("Id", "At"))
         }
         return {**live, **body, f"{entity}Id": entity_id}
-
-    def _children(self, resource: Resource, parent_kind: str, service_id: str, record: dict) -> list[dict]:
-        """Fetch the live children of a resource kind for a parent service."""
-        lookup = LIST_LOOKUP.get(resource.kind)
-        if lookup is not None:
-            route, id_param, type_param = lookup
-            raw = self.client.request("GET", route, {id_param: service_id, type_param: parent_kind}).json()
-            return raw if isinstance(raw, list) else raw.get("items", [])
-        return record.get(child_array_key(resource.kind)) or []
 
     def _resolve_named(self, entity: str, name: str) -> str:
         """Resolve a named reference (e.g. ``destination``) to its id."""

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,0 +1,153 @@
+"""Prune tests (issue #49)."""
+
+from dokli.manifest import ApplicationService, ComposeService, Manifest, ProjectDef, Resource
+from dokli.report import ApplyReport
+from dokli.prune import Pruner
+
+SPECS = {
+    "domain": ("domain.delete", "domainId", {}),
+    "application": ("application.delete", "applicationId", {}),
+    "compose": ("compose.delete", "composeId", {"deleteVolumes": False}),
+}
+
+
+def _service(kind, name, service_id):
+    return type("S", (), {"type": kind, "name": name, "service_id": service_id})()
+
+
+def _service_def(kind, name):
+    if kind == "compose":
+        return ComposeService(name=name)
+    return ApplicationService(name=name)
+
+
+def _project(name, *services):
+    project = type(
+        "P",
+        (),
+        {
+            "name": name,
+            "environments": [
+                type(
+                    "E",
+                    (),
+                    {"name": "", "is_default": True, "environment_id": "e1", "services": list(services)},
+                )()
+            ],
+        },
+    )()
+    return project
+
+
+def _state(*projects):
+    return type("S", (), {"projects": list(projects)})()
+
+
+class FakeClient:
+    def __init__(self, records=None):
+        self.calls = []
+        self.records = records or {}
+
+    def request(self, method, path, params):
+        self.calls.append((method, path, params))
+        records = self.records
+
+        class _Response:
+            def json(self):
+                return records.get(path, {})
+
+        return _Response()
+
+
+def _pruner(manifest, client, state, mocker):
+    mocker.patch("dokli.prune.delete_spec", side_effect=lambda registry, kind: SPECS.get(kind))
+    applier = type("A", (), {})()
+    applier.manifest = manifest
+    applier.client = client
+    applier.report = ApplyReport()
+    applier._state = state
+    return Pruner(applier, {})
+
+
+def _manifest(*projects, resources=()):
+    return Manifest(connection="test", projects=list(projects), resources=list(resources))
+
+
+class TestPruner:
+    """Destructive reconciliation."""
+
+    def test_prunes_unmanaged_service(self, mocker):
+        """We expect services not in the manifest to be deleted."""
+        client = FakeClient({})
+        state = _state(_project("app", _service("application", "web", "a1"), _service("application", "legacy", "a2")))
+        project = ProjectDef(name="app", services=[_service_def("application", "web")])
+        pruner = _pruner(_manifest(project), client, state, mocker)
+
+        pruner.run()
+
+        deletes = [a for a in pruner.report.actions if a.action == "delete"]
+        assert [d.name for d in deletes] == ["legacy"]
+        assert ("POST", "application.delete", {"body": {"applicationId": "a2"}}) in client.calls
+
+    def test_prunes_unmanaged_children(self, mocker):
+        """We expect child records not in the manifest to be deleted."""
+        client = FakeClient(
+            {
+                "compose.one": {
+                    "composeId": "c1",
+                    "domains": [
+                        {"domainId": "d1", "host": "keep.example.com"},
+                        {"domainId": "d2", "host": "drop.example.com"},
+                    ],
+                }
+            }
+        )
+        state = _state(_project("app", _service("compose", "backend", "c1")))
+        project = ProjectDef(name="app", services=[_service_def("compose", "backend")])
+        resource = Resource(
+            kind="domain", name="keep.example.com", in_="compose:backend", data={"host": "keep.example.com"}
+        )
+        pruner = _pruner(_manifest(project, resources=[resource]), client, state, mocker)
+
+        pruner.run()
+
+        deletes = [a for a in pruner.report.actions if a.action == "delete"]
+        assert [d.name for d in deletes] == ["drop.example.com"]
+        assert ("POST", "domain.delete", {"body": {"domainId": "d2"}}) in client.calls
+
+    def test_compose_delete_includes_defaults(self, mocker):
+        """We expect required delete defaults (deleteVolumes) to be sent."""
+        client = FakeClient({})
+        state = _state(_project("app", _service("compose", "legacy", "c1")))
+        project = ProjectDef(name="app", services=[])
+        pruner = _pruner(_manifest(project), client, state, mocker)
+
+        pruner.run()
+
+        assert ("POST", "compose.delete", {"body": {"composeId": "c1", "deleteVolumes": False}}) in client.calls
+
+    def test_leaves_undeclared_projects(self, mocker):
+        """We expect projects not in the manifest to be untouched."""
+        client = FakeClient({})
+        state = _state(
+            _project("app", _service("application", "web", "a1")),
+            _project("other", _service("application", "web", "a9")),
+        )
+        project = ProjectDef(name="app", services=[_service_def("application", "web")])
+        pruner = _pruner(_manifest(project), client, state, mocker)
+
+        pruner.run()
+
+        assert not any(a.action == "delete" for a in pruner.report.actions)
+
+    def test_dry_run_records_without_calling(self, mocker):
+        """We expect dry-run to record deletes without calling the API."""
+        client = FakeClient({})
+        state = _state(_project("app", _service("application", "legacy", "a2")))
+        project = ProjectDef(name="app", services=[])
+        pruner = _pruner(_manifest(project), client, state, mocker)
+
+        pruner.run(dry_run=True)
+
+        assert [a.action for a in pruner.report.actions] == ["delete"]
+        assert not any("application.delete" in c[1] for c in client.calls)


### PR DESCRIPTION
Closes #49: `apply --prune` reconciles destructively — within projects declared
in the manifest, child records and services not described there are deleted.

## What
- **Scope** (per design decision): delete unmanaged child records + services
  only inside projects that *are* in the manifest. Projects and environments
  absent from the manifest are never touched. Order: children first, then
  services.
- `dokli/prune.py`: `Pruner` reuses the resource machinery (`_find_live_service`,
  `fetch_children`, match keys) to index desired children per service and
  delete the rest.
- **Schema-driven delete routes**: `delete_spec()` derives `route`, id field and
  required defaults from the entity's destructive actions (`delete`/`remove`)
  — no hardcoded route map; `DELETE_DEFAULTS` covers `compose.delete`'s
  required `deleteVolumes`.
- `ApplyAction` gains `"delete"`; `apply`/`plan` gain `--prune` (`plan --prune`
  previews deletes via a dry-run applier).
- Apply re-captures state when pruning so freshly-created services are seen.

## Verified
- 223 tests; `make lint` clean.
- E2E on meche (scratch project): applied web+api+domain, then `apply` with a
  manifest containing only the compose + `--prune` deleted the unmanaged
  application and the domain; re-run reported "No changes." Cleaned up.
