### PR TITLE
DOKLI-51-f1: shell completion for connection names

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Uses the cross-platform [`keyring`](https://pypi.org/project/keyring/) package (
   - support for all API entities actions/verbs.
 - magical JSON parameters `%json:{"projectId": "daspdoada798sda"}`
 - magical file parameters `%file:/path/to/data/foo.redis.json`
+- shell completion for configured connection names (`dokli state <TAB>`, `dokli connections get <TAB>`, ...)
 - output formats:
   - yaml
   - json

--- a/dokli/cli.py
+++ b/dokli/cli.py
@@ -9,7 +9,7 @@ from rich.table import Table
 
 from dokli.api_client import APIClient
 from dokli.apply import Applier
-from dokli.config import Config, ConnectionConfig
+from dokli.config import Config, ConnectionConfig, complete_connection_names
 from dokli.connections import build_command as build_connections_command
 from dokli.diff import build_plan
 from dokli.export import export_manifest
@@ -38,7 +38,11 @@ app.add_typer(build_connections_command(state["config"]))
 app.add_typer(build_secrets_command())
 
 
-def tui_command(connection_name: str | None = typer.Argument(None, help="Connection name.")) -> None:
+def tui_command(
+    connection_name: str | None = typer.Argument(
+        None, help="Connection name.", shell_complete=complete_connection_names
+    ),
+) -> None:
     """Text User Interface."""
     assert tui, "TUI not loaded"
     tui.config = state["config"]
@@ -78,7 +82,11 @@ def init_command(
 
 
 @app.command(name="refresh")
-def refresh_command(connection_name: str | None = typer.Argument(None, help="Connection name.")) -> None:
+def refresh_command(
+    connection_name: str | None = typer.Argument(
+        None, help="Connection name.", shell_complete=complete_connection_names
+    ),
+) -> None:
     """Refetch and refresh the cached OpenAPI schema for a connection."""
     connection = _get_connection(connection_name)
     APIClient(connection, force_refresh=True)
@@ -87,7 +95,9 @@ def refresh_command(connection_name: str | None = typer.Argument(None, help="Con
 
 @app.command(name="state")
 def state_command(
-    connection_name: str | None = typer.Argument(None, help="Connection name."),
+    connection_name: str | None = typer.Argument(
+        None, help="Connection name.", shell_complete=complete_connection_names
+    ),
     show_secrets: bool = typer.Option(False, "--show-secrets", help="Show environment variables (secrets)."),
 ) -> None:
     """Show the current state of a Dokploy instance."""
@@ -206,7 +216,9 @@ def validate_command(
 
 @app.command(name="export")
 def export_command(
-    connection_name: str | None = typer.Argument(None, help="Connection name."),
+    connection_name: str | None = typer.Argument(
+        None, help="Connection name.", shell_complete=complete_connection_names
+    ),
     output: str = typer.Option("dokploy.yaml", "--output", "-o", help="Output file, or '-' for stdout."),
     include_secrets: bool = typer.Option(False, "--include-secrets", help="Export environment variables (secrets)."),
 ) -> None:

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -7,10 +7,17 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from click.shell_completion import CompletionItem
 from pydantic import BaseModel, Field, HttpUrl, SecretStr, field_serializer, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, YamlConfigSettingsSource
 
 from dokli.secrets import conn_account, get_secret
+
+
+def complete_connection_names(ctx: Any, param: Any, incomplete: str) -> list[CompletionItem]:
+    """Click shell completion for the configured connection names."""
+    names = [connection.name for connection in Config().connections]
+    return [CompletionItem(name) for name in names if name.startswith(incomplete)]
 
 
 class ConnectionConfig(BaseModel):

--- a/dokli/connections.py
+++ b/dokli/connections.py
@@ -7,7 +7,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from dokli.api_client import APIClient
-from dokli.config import Config, ConnectionConfig
+from dokli.config import Config, ConnectionConfig, complete_connection_names
 from dokli.formatting import redact_secrets
 from dokli.secrets import conn_account, set_secret
 
@@ -37,7 +37,7 @@ def build_command(config: Config) -> typer.Typer:
 
     @group.command("update")
     def update_connection(
-        name: str = typer.Argument(..., help="Connection name."),
+        name: str = typer.Argument(..., help="Connection name.", shell_complete=complete_connection_names),
         new_name: str | None = typer.Argument(None, help="New name (renames the connection)."),
         url: str | None = typer.Option(None, "--url", help="New URL."),
         api_key: str | None = typer.Option(None, "--api-key", help="New API key (64 chars)."),
@@ -51,17 +51,23 @@ def build_command(config: Config) -> typer.Typer:
         _update_connection(config, name, new_name, url, api_key, api_key_cmd, keyring, notes)
 
     @group.command("remove")
-    def remove_connection(name: str = typer.Argument(..., help="Connection name.")) -> None:
+    def remove_connection(
+        name: str = typer.Argument(..., help="Connection name.", shell_complete=complete_connection_names)
+    ) -> None:
         """Remove a connection."""
         _remove_connection(config, name)
 
     @group.command("get")
-    def get_connection(name: str = typer.Argument(..., help="Connection name.")) -> None:
+    def get_connection(
+        name: str = typer.Argument(..., help="Connection name.", shell_complete=complete_connection_names)
+    ) -> None:
         """Show a connection (key masked)."""
         _get_connection(config, name)
 
     @group.command("test")
-    def test_connection(name: str = typer.Argument(..., help="Connection name.")) -> None:
+    def test_connection(
+        name: str = typer.Argument(..., help="Connection name.", shell_complete=complete_connection_names)
+    ) -> None:
         """Validate a connection against the live instance."""
         _test_connection(config, name)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import typer
 
 import dokli.cli
 from dokli.cli import app, main, refresh_command, tui_command
-from dokli.config import Config, ConnectionConfig
+from dokli.config import Config, ConnectionConfig, complete_connection_names
 from dokli.openapi_cli import build_command
 
 
@@ -94,3 +94,42 @@ def test_build_command_skips_broken_connection(mocker):
     names = [group.name for group in api_group.registered_groups]
     assert "good" in names
     assert "bad" not in names
+
+
+def test_complete_connection_names_filters_by_prefix(mocker):
+    """We expect completion to offer configured connections matching the prefix."""
+    mocker.patch(
+        "dokli.config.Config",
+        return_value=Config(
+            connections=[
+                ConnectionConfig(name="meche", url="https://meche.lan", api_key_cmd="echo key"),
+                ConnectionConfig(name="hot-test", url="https://test.lan", api_key_cmd="echo key"),
+            ]
+        ),
+    )
+
+    assert [item.value for item in complete_connection_names(None, None, "mech")] == ["meche"]
+    assert [item.value for item in complete_connection_names(None, None, "hot")] == ["hot-test"]
+    assert complete_connection_names(None, None, "zzz") == []
+
+
+def test_connection_arguments_expose_shell_complete():
+    """We expect connection-name arguments to carry a shell_complete callback."""
+    from typer.main import get_command
+
+    group = get_command(app)
+    for name in ("refresh", "state", "export", "tui"):
+        command = group.get_command(None, name)
+        param = next(p for p in command.params if p.name == "connection_name")
+        assert param._custom_shell_complete is complete_connection_names
+
+
+def test_connections_group_arguments_expose_shell_complete():
+    """We expect connections subcommands to complete existing names."""
+    from typer.main import get_command
+
+    group = get_command(app).get_command(None, "connections")
+    for name in ("update", "remove", "get", "test"):
+        command = group.get_command(None, name)
+        param = next(p for p in command.params if p.name == "name")
+        assert param._custom_shell_complete is complete_connection_names


### PR DESCRIPTION
Closes #51: shell completion for configured connection names.

- `complete_connection_names()` in `dokli/config.py` (click `CompletionItem`s
  filtered by prefix, from the current config — no schema/network involved).
- Wired into every connection-name argument: `state`/`refresh`/`export`/`tui`
  and the `connections` `update`/`remove`/`get`/`test` subcommands.
- The `api` group already completes connection/entity sub-commands (click
  completes sub-typers), and `build_command` already skips unreachable
  connections gracefully — nothing needed there.

Verified: `dokli state mech<TAB>` → `meche`; `dokli connections get <TAB>` →
configured names. 229 tests; `make lint` clean.
