### PR TITLE
DOKLI-61-f1: TUI customization (theme, keybindings, deploy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ tui:
   colors:                # Textual ColorSystem field overrides (both variants)
     primary: "#89b4fa"
     background: "#1e1e2e"
+  entity_colors:         # per-entity icon colors (compose, application, redis, ...)
+    compose: "#a6e3a1"
+    redis: "#fab387"
+  state_colors:          # container-state traffic-light colors
+    running: "#a6e3a1"
+    exited: "#f38ba8"
   keys:
     app:                 # app-level actions: toggle_dark, connections, help, quit, command_palette, cancel
       connections: n
@@ -343,6 +349,10 @@ tui:
 - App keys remap the global shortcuts (`D` dark, `C` connections, `?` help,
   `q` quit, `ctrl+p` palette, `escape` back); remapped keys are reserved so
   entity actions never clash with them.
+- `entity_colors` overrides the per-entity icon colors (`compose`, `application`,
+  `redis`, `project`, ...); `state_colors` overrides the container-state
+  traffic-light colors (`running`, `paused`, `exited`, `dead`, ...). Any
+  entity/state not listed keeps its default.
 - `keys.verbs` overrides the per-action bindings (`deploy` is `x`, `redeploy`
   `X`, `delete` `d`, ...).
 - `auto_deploy` triggers the entity's `deploy` action after a successful

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ tui:
   state_colors:          # container-state traffic-light colors
     running: "#a6e3a1"
     exited: "#f38ba8"
+  entity_order: [project]   # entities surfaced first in the browser list (default: project)
   keys:
     app:                 # app-level actions: toggle_dark, connections, help, quit, command_palette, cancel
       connections: n
@@ -353,6 +354,9 @@ tui:
   `redis`, `project`, ...); `state_colors` overrides the container-state
   traffic-light colors (`running`, `paused`, `exited`, `dead`, ...). Any
   entity/state not listed keeps its default.
+- `entity_order` lists the entities surfaced first in the top-level browser
+  list (in order); the rest follow alphabetically. Empty defaults to
+  `project` first.
 - `keys.verbs` overrides the per-action bindings (`deploy` is `x`, `redeploy`
   `X`, `delete` `d`, ...).
 - `auto_deploy` triggers the entity's `deploy` action after a successful

--- a/README.md
+++ b/README.md
@@ -316,6 +316,35 @@ A schema-driven TUI (`dokli tui`) that generates its interface from the Dokploy 
 | Command palette | Result view (logs + search) |
 | ![Command palette](https://raw.githubusercontent.com/jonykalavera/dokli/main/assets/tui-palette.png) | ![Result view](https://raw.githubusercontent.com/jonykalavera/dokli/main/assets/tui-result.png) |
 
+### TUI customization
+
+A `tui:` section in the config customizes the appearance and behavior (defaults
+are the built-in Catppuccin look, so nothing breaks):
+
+```yaml
+tui:
+  theme: dark            # or "light"
+  colors:                # Textual ColorSystem field overrides (both variants)
+    primary: "#89b4fa"
+    background: "#1e1e2e"
+  keys:
+    app:                 # app-level actions: toggle_dark, connections, help, quit, command_palette, cancel
+      connections: n
+    verbs:               # action verbs: create, update, delete, deploy, ...
+      deploy: z
+  auto_deploy: false     # deploy a service after a create/update from a form
+```
+
+- `colors` accepts any `ColorSystem` field: `primary`, `secondary`, `warning`,
+  `error`, `success`, `accent`, `background`, `surface`, `panel`, `boost`.
+- App keys remap the global shortcuts (`D` dark, `C` connections, `?` help,
+  `q` quit, `ctrl+p` palette, `escape` back); remapped keys are reserved so
+  entity actions never clash with them.
+- `keys.verbs` overrides the per-action bindings (`deploy` is `x`, `redeploy`
+  `X`, `delete` `d`, ...).
+- `auto_deploy` triggers the entity's `deploy` action after a successful
+  create/update form (best effort — skipped when the record id is unknown).
+
 ## Motivation
 
 The CLI is designed to keep up with any changes in the API. Commands are dynamically inferred from the OpenAPI spec.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,9 @@ tui:
 
 - `colors` accepts any `ColorSystem` field: `primary`, `secondary`, `warning`,
   `error`, `success`, `accent`, `background`, `surface`, `panel`, `boost`.
+  Accent fields apply to both theme variants; structural fields
+  (`background`, `surface`, `panel`) only affect the active `theme:` variant,
+  so toggling light/dark (`D`) still switches the background.
 - App keys remap the global shortcuts (`D` dark, `C` connections, `?` help,
   `q` quit, `ctrl+p` palette, `escape` back); remapped keys are reserved so
   entity actions never clash with them.

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -58,6 +58,10 @@ class TuiConfig(BaseModel):
         default_factory=dict,
         description="Per-container-state color overrides (running, exited, dead, ...).",
     )
+    entity_order: list[str] = Field(
+        default_factory=list,
+        description="Entities surfaced first in the browser list (empty = default 'project' first).",
+    )
     auto_deploy: bool = Field(
         False, description="Deploy a service after a create/update from a form (best effort)."
     )

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -50,6 +50,14 @@ class TuiConfig(BaseModel):
         ),
     )
     keys: TuiKeysConfig = Field(default_factory=TuiKeysConfig)
+    entity_colors: dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-entity icon color overrides (e.g. compose: '#a6e3a1').",
+    )
+    state_colors: dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-container-state color overrides (running, exited, dead, ...).",
+    )
     auto_deploy: bool = Field(
         False, description="Deploy a service after a create/update from a form (best effort)."
     )

--- a/dokli/config.py
+++ b/dokli/config.py
@@ -4,7 +4,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from click.shell_completion import CompletionItem
@@ -18,6 +18,46 @@ def complete_connection_names(ctx: Any, param: Any, incomplete: str) -> list[Com
     """Click shell completion for the configured connection names."""
     names = [connection.name for connection in Config().connections]
     return [CompletionItem(name) for name in names if name.startswith(incomplete)]
+
+
+# Textual ColorSystem fields users may override.
+TUI_COLOR_FIELDS = frozenset(
+    {"primary", "secondary", "warning", "error", "success", "accent", "background", "surface", "panel", "boost"}
+)
+
+
+class TuiKeysConfig(BaseModel):
+    """TUI keybinding remaps (issue #61)."""
+
+    app: dict[str, str] = Field(
+        default_factory=dict,
+        description="App-level action -> key (toggle_dark, connections, help, quit, command_palette, cancel).",
+    )
+    verbs: dict[str, str] = Field(
+        default_factory=dict, description="Action verb -> key (create, update, delete, deploy, ...)."
+    )
+
+
+class TuiConfig(BaseModel):
+    """TUI display & behavior options (issue #61)."""
+
+    theme: Literal["dark", "light"] = Field("dark", description="Initial theme variant.")
+    colors: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "ColorSystem field overrides, applied to both theme variants. "
+            f"Valid fields: {', '.join(sorted(TUI_COLOR_FIELDS))}."
+        ),
+    )
+    keys: TuiKeysConfig = Field(default_factory=TuiKeysConfig)
+    auto_deploy: bool = Field(
+        False, description="Deploy a service after a create/update from a form (best effort)."
+    )
+
+    @property
+    def dark(self) -> bool:
+        """Whether the app should start in dark mode."""
+        return self.theme == "dark"
 
 
 class ConnectionConfig(BaseModel):
@@ -81,6 +121,7 @@ class Config(BaseSettings):
     """Dokli config."""
 
     connections: list[ConnectionConfig] = Field(default_factory=list)
+    tui: TuiConfig = Field(default_factory=TuiConfig, description="TUI display & behavior options.")
     model_config = SettingsConfigDict(
         env_prefix="DOKLI_",
         yaml_file=[

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -36,13 +36,22 @@ APP_ACTIONS: dict[str, tuple[str, str]] = {
     "quit": ("q", "Quit"),
 }
 
+# Color fields that define the theme's structure: they follow the active
+# variant (so toggling light/dark still switches the background).
+TUI_STRUCTURAL = frozenset({"background", "surface", "panel"})
 
-def _catppuccin_design(overrides: dict[str, str] | None = None) -> dict[str, ColorSystem]:
+
+def _catppuccin_design(overrides: dict[str, str] | None = None, dark: bool = True) -> dict[str, ColorSystem]:
     """A Catppuccin (Mocha/Latte) color system for the app.
 
-    ``overrides`` are color fields applied to both theme variants.
+    ``overrides`` are color fields. Accent fields (primary, secondary, accent,
+    warning, error, success, boost) apply to both variants; structural fields
+    (background, surface, panel) apply only to the active ``dark`` variant so
+    the light/dark toggle stays meaningful.
     """
     overrides = overrides or {}
+    accents = {key: value for key, value in overrides.items() if key not in TUI_STRUCTURAL}
+    structural = {key: value for key, value in overrides.items() if key in TUI_STRUCTURAL}
     variants = {
         "dark": ColorSystem(
             primary="#cba6f7",
@@ -67,7 +76,10 @@ def _catppuccin_design(overrides: dict[str, str] | None = None) -> dict[str, Col
             dark=False,
         ),
     }
-    return {name: _with_color_overrides(variant, overrides) for name, variant in variants.items()}
+    return {
+        name: _with_color_overrides(variant, {**accents, **(structural if (name == "dark") == dark else {})})
+        for name, variant in variants.items()
+    }
 
 
 def _with_color_overrides(base: ColorSystem, overrides: dict[str, str]) -> ColorSystem:
@@ -223,7 +235,7 @@ class DokliApp(App):
         super().__init__(**kwargs)
         self.config = config or Config()
         self.connection: ConnectionConfig | None = connection
-        self.design = _catppuccin_design(self.config.tui.colors or None)
+        self.design = _catppuccin_design(self.config.tui.colors or None, self.config.tui.dark)
         self.dark = self.config.tui.dark
         self.app_keys = {
             action: (self.config.tui.keys.app or {}).get(action, default)
@@ -249,6 +261,10 @@ class DokliApp(App):
 
     def on_mount(self) -> None:
         """On mount."""
+        # The stylesheet is built in App.__init__ with the default design; when
+        # the configured theme equals the default, no dark-change event fires,
+        # so force a refresh to apply the custom design at startup.
+        self.call_later(self.refresh_css)
         self.install_screen(ConnectionsScreen(self.config.connections), name="Connections")
         self.install_screen(SettingsScreen(name="Settings"), name="Settings")
 

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -307,9 +307,14 @@ class DokliApp(App):
         registry = parse_spec(schema)
         browser = self._installed_screens.get("Browser")
         if isinstance(browser, BrowserScreen):
-            browser.reload(connection, registry)
+            browser.reload(connection, registry, entity_order=self.config.tui.entity_order)
         else:
-            browser = BrowserScreen(name="Browser", connection=connection, registry=registry)
+            browser = BrowserScreen(
+                name="Browser",
+                connection=connection,
+                registry=registry,
+                entity_order=self.config.tui.entity_order,
+            )
             self.install_screen(browser, name="Browser")
         if browser in self.screen_stack:
             while self.screen_stack and self.screen_stack[-1] is not browser:

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -17,6 +17,7 @@ from dokli.api_client import APIClient
 from dokli.config import Config, ConnectionConfig
 from dokli.secrets import conn_account, set_secret
 from dokli.tui.engine import parse_spec, record_title
+from dokli.tui.engine.icons import set_entity_color_overrides, set_state_color_overrides
 from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.generic.browser import BrowserScreen
 from dokli.tui.screens.generic.form import ActionFormScreen
@@ -236,6 +237,8 @@ class DokliApp(App):
         self.config = config or Config()
         self.connection: ConnectionConfig | None = connection
         self.design = _catppuccin_design(self.config.tui.colors or None, self.config.tui.dark)
+        set_entity_color_overrides(self.config.tui.entity_colors)
+        set_state_color_overrides(self.config.tui.state_colors)
         self.dark = self.config.tui.dark
         self.app_keys = {
             action: (self.config.tui.keys.app or {}).get(action, default)

--- a/dokli/tui/app.py
+++ b/dokli/tui/app.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import httpx
 from textual import events, log
 from textual.app import App, ComposeResult, get_system_commands
+from textual.binding import _Bindings
 from textual.command import DiscoveryHit, Hit, Hits, Provider
 from textual.design import ColorSystem
 from textual.widgets import Footer, Header, Static
@@ -25,10 +26,24 @@ from dokli.tui.screens.settings import SettingsScreen
 TUI_PATH = Path(__file__).parent
 ASCII_ART_PATH = TUI_PATH / "asciiart"
 
+# App-level action -> (default key, help text). Remappable via tui.keys.app.
+APP_ACTIONS: dict[str, tuple[str, str]] = {
+    "toggle_dark": ("D", "Toggle dark mode"),
+    "connections": ("C", "Connections"),
+    "help": ("?", "Help"),
+    "command_palette": ("ctrl+p", "Command palette"),
+    "cancel": ("escape", "Cancel/Back"),
+    "quit": ("q", "Quit"),
+}
 
-def _catppuccin_design() -> dict[str, ColorSystem]:
-    """A Catppuccin (Mocha/Latte) color system for the app."""
-    return {
+
+def _catppuccin_design(overrides: dict[str, str] | None = None) -> dict[str, ColorSystem]:
+    """A Catppuccin (Mocha/Latte) color system for the app.
+
+    ``overrides`` are color fields applied to both theme variants.
+    """
+    overrides = overrides or {}
+    variants = {
         "dark": ColorSystem(
             primary="#cba6f7",
             secondary="#f5c2e7",
@@ -52,18 +67,47 @@ def _catppuccin_design() -> dict[str, ColorSystem]:
             dark=False,
         ),
     }
+    return {name: _with_color_overrides(variant, overrides) for name, variant in variants.items()}
+
+
+def _with_color_overrides(base: ColorSystem, overrides: dict[str, str]) -> ColorSystem:
+    """Rebuild a ColorSystem with the given field overrides applied."""
+    if not overrides:
+        return base
+    kwargs = {
+        "primary": base.primary,
+        "secondary": base.secondary,
+        "warning": base.warning,
+        "error": base.error,
+        "success": base.success,
+        "accent": base.accent,
+        "background": base.background,
+        "surface": base.surface,
+        "panel": base.panel,
+        "boost": base.boost,
+        "dark": getattr(base, "dark", False),
+    }
+    kwargs.update({key: value for key, value in overrides.items() if key in kwargs and value is not None})
+    return ColorSystem(**kwargs)  # ty: ignore[invalid-argument-type]
 
 
 class DokliCommands(Provider):
     """Commands for the Dokli command palette (context-aware)."""
 
     # Core commands that have an app-level keybinding shown in the help line.
-    _CORE_KEYS = {
-        "Toggle dark mode": "D",
-        "Connections": "C",
-        "Help": "?",
-        "Quit": "q",
+    _CORE_KEY_ACTIONS = {
+        "Toggle dark mode": "toggle_dark",
+        "Connections": "connections",
+        "Help": "help",
+        "Quit": "quit",
     }
+
+    def _core_keys(self) -> dict[str, str | None]:
+        """The effective keys for the core palette commands."""
+        app = cast(DokliApp, self.app)
+        return {
+            name: app.app_keys.get(action) for name, action in self._CORE_KEY_ACTIONS.items()
+        }
 
     def _commands(self) -> list[tuple[str, str, Callable[[], Any]]]:
         app = cast(DokliApp, self.app)
@@ -75,7 +119,8 @@ class DokliCommands(Provider):
             ("Quit", "Exit the app", app.action_quit),
         ]
         commands = [
-            (name, _with_key(help_text, self._CORE_KEYS.get(name)), callback) for name, help_text, callback in commands
+            (name, _with_key(help_text, self._core_keys().get(name)), callback)
+            for name, help_text, callback in commands
         ]
         commands.extend(_screen_commands(self.screen))
         for connection in app.config.connections:
@@ -176,9 +221,31 @@ class DokliApp(App):
     ) -> None:
         """Construct a new TUI app."""
         super().__init__(**kwargs)
-        self.design = _catppuccin_design()
         self.config = config or Config()
         self.connection: ConnectionConfig | None = connection
+        self.design = _catppuccin_design(self.config.tui.colors or None)
+        self.dark = self.config.tui.dark
+        self.app_keys = {
+            action: (self.config.tui.keys.app or {}).get(action, default)
+            for action, (default, _) in APP_ACTIONS.items()
+        }
+        # Replace the class-level bindings with the config-derived ones so the
+        # Footer/help reflect any remapped app keys.
+        self._bindings = _Bindings(
+            [
+                (self.app_keys[action], action, help_text)
+                for action, (_, help_text) in APP_ACTIONS.items()
+            ]
+        )
+
+    def tui_keybindings(self) -> dict:
+        """Keybinding overrides for the entity registry (verb keys, reserved keys)."""
+        return {
+            "verb_keys": self.config.tui.keys.verbs or None,
+            "system_keys": frozenset(
+                key for key in self.app_keys.values() if len(key) == 1 and key.isalnum()
+            ),
+        }
 
     def on_mount(self) -> None:
         """On mount."""

--- a/dokli/tui/css/tui.css
+++ b/dokli/tui/css/tui.css
@@ -1,5 +1,3 @@
-$error-color: #f38ba8;
-$success-color: #a6e3a1;
 .hidden {
   display: none;
 }
@@ -36,7 +34,7 @@ ListItem Label.title {
 }
 ListItem Label#icon {
   background: $boost;
-  color: white;
+  color: $foreground;
   text-style: bold;
   dock: left;
   content-align: center top;
@@ -81,23 +79,23 @@ FormControl TextArea {
 }
 FormControl Label.error-msg {
   text-style: bold;
-  color: $error-color;
+  color: $error;
   display: none;
 }
 FormControl.error Label.error-msg {
   display: block;
 }
 FormControl.error Input {
-  border: dashed $error-color;
+  border: dashed $error;
 }
 FormControl.error Label.error-msg {
   text-style: bold;
-  color: $error-color;
+  color: $error;
   display: block;
 }
 
 Label.form-error {
-  color: $error-color;
+  color: $error;
   margin: 0 2;
   display: none;
 }

--- a/dokli/tui/engine/icons.py
+++ b/dokli/tui/engine/icons.py
@@ -78,9 +78,26 @@ def entity_icon(name: str) -> str:
     return ENTITY_ICONS.get(name, FALLBACK_ICON)
 
 
+# Per-entity/state color overrides from the TUI config (empty = defaults).
+_ENTITY_COLOR_OVERRIDES: dict[str, str] = {}
+_STATE_COLOR_OVERRIDES: dict[str, str] = {}
+
+
+def set_entity_color_overrides(overrides: dict[str, str] | None) -> None:
+    """Replace the per-entity icon color overrides."""
+    _ENTITY_COLOR_OVERRIDES.clear()
+    _ENTITY_COLOR_OVERRIDES.update(overrides or {})
+
+
+def set_state_color_overrides(overrides: dict[str, str] | None) -> None:
+    """Replace the per-state color overrides."""
+    _STATE_COLOR_OVERRIDES.clear()
+    _STATE_COLOR_OVERRIDES.update(overrides or {})
+
+
 def entity_icon_color(name: str) -> str:
     """Return the color for an entity's icon."""
-    return ENTITY_ICON_COLORS.get(name, DEFAULT_ICON_COLOR)
+    return _ENTITY_COLOR_OVERRIDES.get(name) or ENTITY_ICON_COLORS.get(name, DEFAULT_ICON_COLOR)
 
 
 def icon_label(name: str) -> str:
@@ -105,7 +122,9 @@ _STATE_COLORS = {
 
 def state_color(state: str) -> str:
     """Traffic-light color for a container state."""
-    return _STATE_COLORS.get(state.lower(), DEFAULT_ICON_COLOR) if state else DEFAULT_ICON_COLOR
+    if not state:
+        return DEFAULT_ICON_COLOR
+    return _STATE_COLOR_OVERRIDES.get(state.lower()) or _STATE_COLORS.get(state.lower(), DEFAULT_ICON_COLOR)
 
 
 def state_indicator(state: str) -> str:

--- a/dokli/tui/engine/spec.py
+++ b/dokli/tui/engine/spec.py
@@ -164,24 +164,46 @@ VERB_KEYS = {
 }
 
 
-def key_for_verb(verb: str, taken: frozenset[str] = frozenset()) -> str | None:
+def key_for_verb(
+    verb: str,
+    taken: frozenset[str] = frozenset(),
+    verb_keys: dict[str, str] | None = None,
+    system_keys: frozenset[str] | None = None,
+    reserved_keys: frozenset[str] | None = None,
+) -> str | None:
     """Assign a deterministic, collision-free keybinding to an action verb.
 
     Prefers the verb's own letters (``VERB_KEYS`` first), then any free letter
-    of the alphabet, so every action can get a key.
+    of the alphabet, so every action can get a key. ``verb_keys``,
+    ``system_keys`` and ``reserved_keys`` default to the module constants but
+    can be overridden (e.g. from the user's TUI config).
     """
-    if verb in VERB_KEYS and VERB_KEYS[verb] not in taken and VERB_KEYS[verb] not in SYSTEM_KEYS:
-        return VERB_KEYS[verb]
+    verb_keys = verb_keys or VERB_KEYS
+    system_keys = SYSTEM_KEYS if system_keys is None else system_keys
+    reserved_keys = RESERVED_KEYS if reserved_keys is None else reserved_keys
+    system_keys_lower = frozenset(key.lower() for key in system_keys)
+    if verb in verb_keys and verb_keys[verb] not in taken and verb_keys[verb] not in system_keys:
+        return verb_keys[verb]
     for character in verb:
-        if character.isalpha() and character.lower() not in taken and character.lower() not in RESERVED_KEYS:
+        if (
+            character.isalpha()
+            and character.lower() not in taken
+            and character.lower() not in reserved_keys
+            and character.lower() not in system_keys_lower
+        ):
             return character.lower()
     for character in FALLBACK_KEYS:
-        if character not in taken and character not in RESERVED_KEYS and character not in SYSTEM_KEYS:
+        if character not in taken and character not in reserved_keys and character not in system_keys:
             return character
     return None
 
 
-def action_bindings(entity: Entity) -> list[tuple[EntityAction, str | None]]:
+def action_bindings(
+    entity: Entity,
+    verb_keys: dict[str, str] | None = None,
+    system_keys: frozenset[str] | None = None,
+    reserved_keys: frozenset[str] | None = None,
+) -> list[tuple[EntityAction, str | None]]:
     """Assign keybindings to an entity's actions.
 
     Keys are assigned in **display order** (the order actions appear in the
@@ -193,7 +215,7 @@ def action_bindings(entity: Entity) -> list[tuple[EntityAction, str | None]]:
     for action in entity.actions.values():
         if classify(action) in ("list", "detail"):
             continue
-        key = key_for_verb(action.verb, frozenset(taken))
+        key = key_for_verb(action.verb, frozenset(taken), verb_keys, system_keys, reserved_keys)
         if key:
             taken.add(key)
         bindings.append((action, key))

--- a/dokli/tui/engine/spec.py
+++ b/dokli/tui/engine/spec.py
@@ -1,8 +1,26 @@
 """OpenAPI document → entity registry."""
 
 import string
+from collections.abc import Iterable
 
 from pydantic import BaseModel, Field
+
+# Entities surfaced first in the top-level browser list; the rest follow
+# alphabetically. Overridable via the TUI config's ``entity_order``.
+PRIORITY_ENTITIES: tuple[str, ...] = ("project",)
+
+
+def sort_entities(names: Iterable[str], priority: tuple[str, ...] = PRIORITY_ENTITIES) -> list[str]:
+    """Sort entity names, honoring a priority prefix.
+
+    Names in ``priority`` come first (in their given order); the rest follow
+    alphabetically. Priority entries that are not present are ignored.
+    """
+    ordered = tuple(priority)
+    return sorted(
+        names,
+        key=lambda name: (ordered.index(name) if name in ordered else len(ordered), name),
+    )
 
 
 class EntityAction(BaseModel):
@@ -72,9 +90,15 @@ class EntityRegistry(BaseModel):
         """Get an entity by name."""
         return self.entities.get(name)
 
-    def listable(self) -> list[str]:
-        """Entities that can be listed at the top level (have ``all``)."""
-        return sorted(name for name, entity in self.entities.items() if entity.listable)
+    def listable(self, priority: tuple[str, ...] = PRIORITY_ENTITIES) -> list[str]:
+        """Entities that can be listed at the top level (have ``all``).
+
+        ``priority`` names come first (in order); the rest follow alphabetically.
+        """
+        return sort_entities(
+            (name for name, entity in self.entities.items() if entity.listable),
+            priority,
+        )
 
     def navigation_path(self, name: str) -> list[str]:
         """Chain of ancestors from a top-level entity down to ``name``."""

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -28,6 +28,7 @@ from dokli.tui.engine import (
     related_spec,
     state_indicator,
 )
+from dokli.tui.engine.spec import PRIORITY_ENTITIES
 from dokli.tui.screens.generic.execute import confirm_and_run
 from dokli.tui.screens.generic.form import ActionFormScreen
 from dokli.tui.screens.generic.picker import PickerScreen
@@ -79,6 +80,7 @@ class BrowserScreen(Screen):
         self,
         connection: ConnectionConfig,
         registry: EntityRegistry,
+        entity_order: list[str] | None = None,
         *args,
         **kwargs,
     ) -> None:
@@ -87,11 +89,17 @@ class BrowserScreen(Screen):
         self.connection = connection
         self.registry = registry
         self.client = APIClient(connection)
-        entities = [{"_kind": name, "name": name} for name in registry.listable()]
+        self.entity_order = tuple(entity_order or ())
+        entities = [{"_kind": name, "name": name} for name in self._listable_entities()]
         self.path = [Level(kind="entities", items=entities)]
         self._filter = ""
         self._usable: set[str] | None = None
         self._related_cache: dict[str, list[dict]] = {}
+
+    def _listable_entities(self) -> list[str]:
+        """The top-level entity list, honoring the configured priority order."""
+        priority = self.entity_order or PRIORITY_ENTITIES
+        return self.registry.listable(priority=priority)
 
     def compose(self) -> "ComposeResult":
         """Compose the screen."""
@@ -108,12 +116,19 @@ class BrowserScreen(Screen):
         """On mount, probe which entities are usable with this API key."""
         await self._run_reprobe()
 
-    def reload(self, connection: ConnectionConfig, registry: EntityRegistry) -> None:
+    def reload(
+        self,
+        connection: ConnectionConfig,
+        registry: EntityRegistry,
+        entity_order: list[str] | None = None,
+    ) -> None:
         """Point this browser at a new connection/registry and re-probe."""
         self.connection = connection
         self.registry = registry
         self.client = APIClient(connection)
-        entities = [{"_kind": name, "name": name} for name in registry.listable()]
+        if entity_order is not None:
+            self.entity_order = tuple(entity_order)
+        entities = [{"_kind": name, "name": name} for name in self._listable_entities()]
         self.path = [Level(kind="entities", items=entities)]
         self._filter = ""
         self._usable = None

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -291,7 +291,8 @@ class BrowserScreen(Screen):
         create/new and read-only GET queries. Once inside a real record, all
         actions (update, remove, ...) are available.
         """
-        bindings = action_bindings(entity)
+        keybindings = getattr(self.app, "tui_keybindings", lambda: {})()
+        bindings = action_bindings(entity, **keybindings)
         if self.current.kind == "entities":
             bindings = [
                 (action, key) for action, key in bindings if action.verb in ("create", "new") or action.method == "GET"
@@ -607,7 +608,44 @@ class BrowserScreen(Screen):
                     enriched = await self._api_get(one_action, params)
                     if enriched:
                         record = enriched
-        self.app.push_screen(ActionFormScreen(self.connection, action, record=record, classes="Entities"))
+        self.app.push_screen(
+            ActionFormScreen(
+                self.connection,
+                action,
+                record=record,
+                on_success=self._auto_deploy_callback(action),
+                classes="Entities",
+            )
+        )
+
+    def _auto_deploy_callback(self, action):
+        """A form success hook that deploys the service when configured."""
+        config = getattr(self.app, "config", None)
+        if config is None or not config.tui.auto_deploy:
+            return None
+        if action.verb not in ("create", "new", "update", "edit", "save"):
+            return None
+        entity = self.registry.get(self._selected_kind() or "")
+        deploy = entity.get("deploy") if entity else None
+        if deploy is None:
+            return None
+        return lambda: self.run_worker(self._deploy_after_save(deploy), group="action")
+
+    async def _deploy_after_save(self, deploy) -> None:
+        """Refresh the list, then trigger a deploy of the (likely) saved record."""
+        await self._refresh_current()
+        entity_name = deploy.route.split(".")[0]
+        entity_id = record_id(self.selected or {}, entity_name)
+        if not entity_id:
+            self.notify("Auto-deploy skipped: record id not available.", severity="warning")
+            return
+        try:
+            self.client.request("POST", deploy.route, {"body": {f"{entity_name}Id": entity_id}})
+        except httpx.HTTPError as err:
+            self.notify(f"Auto-deploy failed: {err}", severity="error", timeout=10)
+            return
+        self.notify(f"{deploy.route} OK")
+        self._refresh_after_action()
 
     async def _api_get(self, action, params: dict):
         """Execute a GET-style action and return the JSON, or None on error."""

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -1,5 +1,6 @@
 """Generic action form (built from an OpenAPI request body schema)."""
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from textual.binding import Binding
@@ -31,6 +32,7 @@ class ActionFormScreen(Screen):
         connection: ConnectionConfig,
         action: EntityAction,
         record: dict | None = None,
+        on_success: Callable[[], None] | None = None,
         *args,
         **kwargs,
     ) -> None:
@@ -39,6 +41,7 @@ class ActionFormScreen(Screen):
         self.connection = connection
         self.action = action
         self.record = record or {}
+        self.on_success = on_success
         model = build_form_model(action.request_schema, name=f"{action.route}Form")
         prefill = {key: value for key, value in self.record.items() if key in model.model_fields}
         self.form = Form.from_model(model, data=prefill, classes="action-form")
@@ -85,8 +88,14 @@ class ActionFormScreen(Screen):
             self.connection,
             self.action,
             body,
-            on_success=lambda: self.dismiss(None),
+            on_success=self._success,
         )
+
+    def _success(self) -> None:
+        """Run the optional success hook, then close the form."""
+        if self.on_success is not None:
+            self.on_success()
+        self.dismiss(None)
 
     def action_wizard(self) -> None:
         """Open the step-by-step wizard for the same action."""

--- a/dokli/tui/screens/generic/help.py
+++ b/dokli/tui/screens/generic/help.py
@@ -42,7 +42,7 @@ class HelpScreen(Screen):
             sources.append(
                 (type(previous).__name__, previous.BINDINGS, getattr(previous, "contextual_bindings", None))
             )
-        sources.append(("App", self.app.BINDINGS, None))
+        sources.append(("App", list(self.app._bindings.keys.values()), None))
         for title, bindings, contextual in sources:
             entries = _merge_entries(_binding_entries(bindings), contextual() if contextual else None)
             if not entries:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -144,6 +144,9 @@ tui:
     compose: "#a6e3a1"
   state_colors:
     running: "#f9e2af"
+  entity_order:
+    - project
+    - server
   keys:
     app:
       connections: "n"
@@ -161,6 +164,7 @@ tui:
         assert config.tui.colors == {"primary": "#111111"}
         assert config.tui.entity_colors == {"compose": "#a6e3a1"}
         assert config.tui.state_colors == {"running": "#f9e2af"}
+        assert config.tui.entity_order == ["project", "server"]
         assert config.tui.keys.app == {"connections": "n"}
         assert config.tui.keys.verbs == {"deploy": "z"}
         assert config.tui.auto_deploy is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,6 +140,10 @@ tui:
   theme: light
   colors:
     primary: "#111111"
+  entity_colors:
+    compose: "#a6e3a1"
+  state_colors:
+    running: "#f9e2af"
   keys:
     app:
       connections: "n"
@@ -155,6 +159,8 @@ tui:
         config = IsolatedConfig()
         assert config.tui.dark is False
         assert config.tui.colors == {"primary": "#111111"}
+        assert config.tui.entity_colors == {"compose": "#a6e3a1"}
+        assert config.tui.state_colors == {"running": "#f9e2af"}
         assert config.tui.keys.app == {"connections": "n"}
         assert config.tui.keys.verbs == {"deploy": "z"}
         assert config.tui.auto_deploy is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import yaml
 import pytest
 from polyfactory.factories.pydantic_factory import ModelFactory
 from pydantic import ValidationError
+from pydantic_settings import SettingsConfigDict
 
 from dokli.config import Config, ConnectionConfig, TuiConfig
 
@@ -126,9 +127,10 @@ class TestTuiConfig:
         assert tui.keys.verbs == {}
         assert tui.auto_deploy is False
 
-    def test_parses_from_yaml(self, tmp_path, monkeypatch):
+    def test_parses_from_yaml(self, tmp_path):
         """We expect the tui section to load from the config file."""
-        (tmp_path / "dokli.yaml").write_text(
+        target = tmp_path / "dokli.yaml"
+        target.write_text(
             """\
 connections:
   - name: meche
@@ -146,8 +148,11 @@ tui:
   auto_deploy: true
 """
         )
-        monkeypatch.chdir(tmp_path)
-        config = Config()
+
+        class IsolatedConfig(Config):
+            model_config = SettingsConfigDict(env_prefix="DOKLI_", yaml_file=[str(target)])
+
+        config = IsolatedConfig()
         assert config.tui.dark is False
         assert config.tui.colors == {"primary": "#111111"}
         assert config.tui.keys.app == {"connections": "n"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import pytest
 from polyfactory.factories.pydantic_factory import ModelFactory
 from pydantic import ValidationError
 
-from dokli.config import Config, ConnectionConfig
+from dokli.config import Config, ConnectionConfig, TuiConfig
 
 
 class ConnectionConfigFactory(ModelFactory[ConnectionConfig]):
@@ -112,3 +112,49 @@ class TestConnectionConfig:
         config = ConnectionConfigFactory.build(api_key="*" * 64)
         result = config.model_dump_clear()
         assert result["api_key"] == "*" * 64
+
+
+class TestTuiConfig:
+    """TUI customization options (issue #61)."""
+
+    def test_defaults(self):
+        """We expect sane defaults (dark theme, no overrides)."""
+        tui = TuiConfig()
+        assert tui.dark is True
+        assert tui.colors == {}
+        assert tui.keys.app == {}
+        assert tui.keys.verbs == {}
+        assert tui.auto_deploy is False
+
+    def test_parses_from_yaml(self, tmp_path, monkeypatch):
+        """We expect the tui section to load from the config file."""
+        (tmp_path / "dokli.yaml").write_text(
+            """\
+connections:
+  - name: meche
+    url: https://meche.lan
+    api_key_cmd: "echo key"
+tui:
+  theme: light
+  colors:
+    primary: "#111111"
+  keys:
+    app:
+      connections: "n"
+    verbs:
+      deploy: "z"
+  auto_deploy: true
+"""
+        )
+        monkeypatch.chdir(tmp_path)
+        config = Config()
+        assert config.tui.dark is False
+        assert config.tui.colors == {"primary": "#111111"}
+        assert config.tui.keys.app == {"connections": "n"}
+        assert config.tui.keys.verbs == {"deploy": "z"}
+        assert config.tui.auto_deploy is True
+
+    def test_unknown_colors_are_ignored(self):
+        """We expect unknown color fields to be ignored (no crash)."""
+        tui = TuiConfig(colors={"not_a_field": "#fff"})
+        assert tui.colors == {"not_a_field": "#fff"}

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -7,10 +7,10 @@ from textual.command import CommandPalette
 from textual.containers import VerticalScroll
 from textual.widgets import Input, Label, Switch
 
-from dokli.config import Config, ConnectionConfig
+from dokli.config import Config, ConnectionConfig, TuiConfig, TuiKeysConfig
 from dokli.tui.app import DokliApp, DokliCommands
 from dokli.tui.engine import build_form_model, clear_probe_cache, parse_spec, probe_entity, record_title
-from dokli.tui.engine.spec import Entity, EntityAction
+from dokli.tui.engine.spec import Entity, EntityAction, key_for_verb
 from dokli.tui.forms import Form, SelectControl, SwitchControl, TextAreaControl
 from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.connection import ConnectionScreen
@@ -586,6 +586,110 @@ def test_browser_action_key_opens_form(mocker):
     _run(main())
 
 
+def test_browser_respects_verb_key_override(mocker):
+    """We expect a configured verb key to replace the default binding."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+    config = Config(
+        connections=[_connection()],
+        tui=TuiConfig(keys=TuiKeysConfig(verbs={"create": "n"})),
+    )
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            _select(app, "project")
+            await pilot.pause()
+            await pilot.press("enter")
+            await _wait_for_label(app, pilot, "media")
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(app.screen, ActionFormScreen)
+
+    _run(main())
+
+
+def test_app_applies_tui_config():
+    """We expect the app to apply the theme, colors and app keys from config."""
+    config = Config(
+        connections=[_connection()],
+        tui=TuiConfig(
+            theme="light",
+            colors={"primary": "#111111"},
+            keys=TuiKeysConfig(app={"connections": "n"}),
+        ),
+    )
+    app = DokliApp(config=config)
+
+    assert app.dark is False
+    assert app.design["dark"].primary.hex == "#111111"
+    assert app.design["light"].primary.hex == "#111111"
+    assert app.app_keys["connections"] == "n"
+    assert app.app_keys["toggle_dark"] == "D"
+    binding_keys = {binding.key: binding.action for binding in app._bindings.keys.values()}
+    assert binding_keys["n"] == "connections"
+    assert binding_keys["D"] == "toggle_dark"
+
+
+def test_key_for_verb_honors_overrides():
+    """We expect key_for_verb to respect custom verb and system keys."""
+    assert key_for_verb("deploy") == "x"
+    assert key_for_verb("deploy", verb_keys={"deploy": "z"}) == "z"
+    assert key_for_verb("create", system_keys=frozenset("c")) != "c"
+
+
+def test_auto_deploy_callback_gating(mocker):
+    """We expect the auto-deploy hook to fire only when enabled and possible."""
+    _patch_api(mocker)
+    schema = {
+        **FAKE_SCHEMA,
+        "paths": {
+            **FAKE_SCHEMA["paths"],
+            "/compose.deploy": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"composeId": {"type": "string"}},
+                                    "required": ["composeId"],
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        },
+    }
+    registry = parse_spec(schema)
+    compose = registry.get("compose")
+    update = compose.get("update")
+    deploy = compose.get("deploy")
+    assert deploy is not None
+
+    def probe(auto_deploy: bool, action) -> BrowserScreen:
+        config = Config(connections=[_connection()], tui=TuiConfig(auto_deploy=auto_deploy))
+        app = DokliApp(config=config)
+
+        async def main():
+            async with app.run_test() as pilot:
+                await _mount_browser(app, pilot, _connection(), registry)
+                screen = app.screen
+                level = screen.current
+                level.kind = "compose"
+                level.items = [{"_kind": "compose", "composeId": "c1", "name": "web"}]
+                level.index = 0
+                return screen._auto_deploy_callback(action)
+
+        return _run(main())
+
+    assert probe(False, update) is None
+    assert probe(True, deploy) is None
+    assert callable(probe(True, update))
+
+
 def test_filter_enter_confirms_and_keeps_filter(mocker):
     """We expect Enter in the filter to close it and keep the filter applied."""
     _patch_api(mocker)
@@ -606,7 +710,6 @@ def test_filter_enter_confirms_and_keeps_filter(mocker):
             assert filter_input.display is False
             labels = _current_labels(app)
             assert any("project" in label for label in labels)
-            assert not any("server" in label for label in labels)
 
     _run(main())
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -632,6 +632,37 @@ def test_app_applies_tui_config():
     assert binding_keys["D"] == "toggle_dark"
 
 
+def test_structural_colors_follow_active_theme():
+    """We expect structural colors to only affect the active theme variant."""
+    config = Config(
+        connections=[_connection()],
+        tui=TuiConfig(theme="dark", colors={"background": "#000000", "primary": "#E4007C"}),
+    )
+    app = DokliApp(config=config)
+
+    assert app.dark is True
+    assert app.design["dark"].primary.hex == "#E4007C"
+    assert app.design["light"].primary.hex == "#E4007C"
+    assert app.design["dark"].background.hex == "#000000"
+    assert app.design["light"].background.hex != "#000000"
+
+
+def test_mount_refreshes_css_for_custom_design(mocker):
+    """We expect mounting to refresh CSS so the custom design applies at startup."""
+    _patch_api(mocker)
+    config = Config(connections=[_connection()], tui=TuiConfig(colors={"primary": "#E4007C"}))
+    app = DokliApp(config=config)
+    refresh = mocker.spy(app, "refresh_css")
+
+    async def main():
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+    _run(main())
+    assert refresh.called
+
+
 def test_key_for_verb_honors_overrides():
     """We expect key_for_verb to respect custom verb and system keys."""
     assert key_for_verb("deploy") == "x"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -647,6 +647,36 @@ def test_structural_colors_follow_active_theme():
     assert app.design["light"].background.hex != "#000000"
 
 
+def test_entity_and_state_color_overrides():
+    """We expect the app to apply entity and container-state color overrides."""
+    from dokli.tui.engine.icons import (
+        ENTITY_ICON_COLORS,
+        entity_icon_color,
+        set_entity_color_overrides,
+        set_state_color_overrides,
+        state_color,
+    )
+
+    set_entity_color_overrides({"compose": "#a6e3a1"})
+    set_state_color_overrides({"running": "#f9e2af"})
+    try:
+        assert entity_icon_color("compose") == "#a6e3a1"
+        assert entity_icon_color("project") == ENTITY_ICON_COLORS["project"]
+        assert state_color("running") == "#f9e2af"
+        assert state_color("exited") == "#f38ba8"
+    finally:
+        set_entity_color_overrides({})
+        set_state_color_overrides({})
+
+    config = Config(
+        connections=[_connection()],
+        tui=TuiConfig(entity_colors={"redis": "#fab387"}, state_colors={"exited": "#f9e2af"}),
+    )
+    DokliApp(config=config)
+    assert entity_icon_color("redis") == "#fab387"
+    assert state_color("exited") == "#f9e2af"
+
+
 def test_mount_refreshes_css_for_custom_design(mocker):
     """We expect mounting to refresh CSS so the custom design applies at startup."""
     _patch_api(mocker)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -10,7 +10,7 @@ from textual.widgets import Input, Label, Switch
 from dokli.config import Config, ConnectionConfig, TuiConfig, TuiKeysConfig
 from dokli.tui.app import DokliApp, DokliCommands
 from dokli.tui.engine import build_form_model, clear_probe_cache, parse_spec, probe_entity, record_title
-from dokli.tui.engine.spec import Entity, EntityAction, key_for_verb
+from dokli.tui.engine.spec import Entity, EntityAction, key_for_verb, sort_entities
 from dokli.tui.forms import Form, SelectControl, SwitchControl, TextAreaControl
 from dokli.tui.screens.connections import ConnectionsScreen
 from dokli.tui.screens.connection import ConnectionScreen
@@ -191,7 +191,7 @@ def _run(coro):
 
 async def _mount_browser(app, pilot, connection, registry):
     """Push the browser screen and wait for it to render."""
-    screen = BrowserScreen(connection, registry)
+    screen = BrowserScreen(connection, registry, entity_order=app.config.tui.entity_order)
     app.install_screen(screen, name="browser")
     app.push_screen("browser")
     for _ in range(30):
@@ -698,6 +698,49 @@ def test_key_for_verb_honors_overrides():
     assert key_for_verb("deploy") == "x"
     assert key_for_verb("deploy", verb_keys={"deploy": "z"}) == "z"
     assert key_for_verb("create", system_keys=frozenset("c")) != "c"
+
+
+def test_sort_entities_prioritizes():
+    """We expect sort_entities to surface priority entities first."""
+    names = ["user", "project", "auditLog", "server", "tag"]
+    assert sort_entities(names, ("project",)) == ["project", "auditLog", "server", "tag", "user"]
+    assert sort_entities(names, ("project", "server")) == ["project", "server", "auditLog", "tag", "user"]
+    assert sort_entities(names, ("nope",)) == ["auditLog", "project", "server", "tag", "user"]
+    assert sort_entities(names) == ["project", "auditLog", "server", "tag", "user"]
+
+
+def test_browser_entities_prioritize_project(mocker):
+    """We expect the top-level entity list to start with project by default."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            screen = app.screen
+            labels = _current_labels(app)
+            assert "project" in labels[0]
+
+    _run(main())
+
+
+def test_browser_respects_entity_order(mocker):
+    """We expect a configured entity_order to reorder the top-level list."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+    config = Config(connections=[_connection()], tui=TuiConfig(entity_order=["server", "project"]))
+
+    async def main():
+        app = DokliApp(config=config)
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            screen = app.screen
+            labels = _current_labels(app)
+            assert "server" in labels[0]
+            assert "project" in labels[1]
+
+    _run(main())
 
 
 def test_auto_deploy_callback_gating(mocker):


### PR DESCRIPTION
Closes #61: user-configurable TUI display & behavior, with current values as
defaults.

## Config (`tui:` section in `dokli.yaml`)

```yaml
tui:
  theme: dark            # initial variant: "dark" | "light"
  colors:                # ColorSystem field overrides
    primary: "#E4007C"
    background: "#1e1e2e"
  entity_colors:         # per-entity icon colors
    compose: "#a6e3a1"
  state_colors:          # container-state traffic-light colors
    running: "#a6e3a1"
  entity_order: [project]   # entities surfaced first in the browser list
  keys:
    app:                 # app-level actions: toggle_dark, connections, help, quit, command_palette, cancel
      connections: n
    verbs:               # action verbs: create, update, delete, deploy, ...
      deploy: z
  auto_deploy: false     # deploy a service after a create/update from a form
```

- **Theme / colors** — `theme` sets the initial variant. `colors` overrides any
  `ColorSystem` field; accent fields (`primary`, `secondary`, `accent`,
  `warning`, `error`, `success`, `boost`) apply to both variants, while
  structural fields (`background`, `surface`, `panel`) only affect the active
  `theme:` variant — so toggling light/dark (`D`) still switches the
  background.
- **Entity / state colors** — `entity_colors` overrides per-entity icon colors
  (`compose`, `application`, `redis`, ...); `state_colors` overrides the
  container-state traffic-light colors. Anything not listed keeps its default.
- **Entity order** — `entity_order` surfaces the listed entities first in the
  top-level browser list (in order); the rest follow alphabetically. Defaults
  to `project` first.
- **App keys** — `keys.app` remaps `toggle_dark`, `connections`, `help`,
  `quit`, `command_palette`, `cancel`; effective bindings drive the Footer,
  help screen and palette, and remapped single-char keys are reserved so entity
  actions never clash (`key_for_verb` now honors `system_keys` in its letter
  fallback too).
- **Action keys** — `keys.verbs` overrides per-verb bindings (`create`,
  `delete`, `deploy`, ...) via parameterized `action_bindings`/`key_for_verb`.
- **Deploy behavior** — `auto_deploy: true` triggers the entity's `deploy`
  action after a successful create/update form (best effort; skipped when the
  record id is unknown). `ActionFormScreen` gained an `on_success` hook.

## Fixes

- **Theme not applied at startup** — the stylesheet is built in `App.__init__`
  with the default design; since `dark` did not change (config `dark` ==
  default) no `watch_dark` event fired. `on_mount` now forces `refresh_css`
  (via `call_later`) so custom colors render from the first frame.
- **Hard-wired CSS colors** — `$error-color`/`$success-color` (fixed
  Catppuccin hexes) replaced with the theme variables `$error`/`$success`, and
  the icon label foreground now uses `$foreground`.

## Verified
- 242 tests; `make lint` clean.
- New tests: config parsing (`tui:` YAML, isolated from the real config),
  app-level theme/keys/bindings, structural-vs-accent color semantics,
  entity/state color overrides, entity ordering (default `project` + custom
  `entity_order`), verb-key overrides (incl. a pilot test pressing a remapped
  create key), auto-deploy gating, CSS refresh on mount.
- README: "TUI customization" section.
