### PR TITLE
DOKLI-69-f1: hide parent-id fields from child forms

### DIFF
--- a/dokli/tui/css/tui.css
+++ b/dokli/tui/css/tui.css
@@ -84,7 +84,7 @@ FormControl Input {
   margin-right: 1;
 }
 FormControl TextArea {
-  height: 5;
+  height: 10;
   width: 100%;
   margin-left: 1;
   margin-right: 1;

--- a/dokli/tui/engine/schemas.py
+++ b/dokli/tui/engine/schemas.py
@@ -27,6 +27,27 @@ READ_ONLY_FIELDS = {
     "refreshToken",
 }
 
+# Id fields that are NOT parent references (ambient/server-managed) and should
+# stay editable in forms. Other ``*Id`` properties are treated as parent-id
+# candidates: mutually-exclusive, hidden from child forms and injected from
+# context instead (see BrowserScreen._parent_id_candidates).
+AMBIENT_ID_FIELDS = frozenset(
+    {
+        "serverId",
+        "destinationId",
+        "registryId",
+        "certificateId",
+        "providerId",
+        "nodeId",
+        "keyId",
+        "sshKeyId",
+        "buildServerId",
+        "buildRegistryId",
+        "rollbackRegistryId",
+        "userId",
+    }
+)
+
 # String fields that are expected to hold multi-line content.
 MULTILINE_FIELDS = {
     "description",
@@ -41,17 +62,21 @@ MULTILINE_FIELDS = {
 }
 
 
-def build_form_model(schema: dict, name: str = "ActionForm") -> type[BaseModel]:
+def build_form_model(
+    schema: dict, name: str = "ActionForm", excluded: set[str] | None = None
+) -> type[BaseModel]:
     """Build a pydantic model from an OpenAPI request body schema.
 
     Used to reuse the existing generic :class:`~dokli.tui.forms.Form` widget,
     which derives controls and validation from a pydantic model. All fields are
     optional (default ``None``); requiredness is enforced by the form screen
-    from the schema's ``required`` list.
+    from the schema's ``required`` list. ``excluded`` fields are dropped from
+    the form (e.g. parent-id fields injected from context).
     """
+    excluded = excluded or set()
     fields: dict[str, Any] = {}
     for field_name, prop in schema.get("properties", {}).items():
-        if field_name in READ_ONLY_FIELDS:
+        if field_name in READ_ONLY_FIELDS or field_name in excluded:
             continue
         annotation = _annotation_for(field_name, prop)
         label = _label_for(field_name)

--- a/dokli/tui/engine/schemas.py
+++ b/dokli/tui/engine/schemas.py
@@ -48,6 +48,25 @@ AMBIENT_ID_FIELDS = frozenset(
     }
 )
 
+# Leaf entities that hang off a service/project as children. Only for these do
+# ``*Id`` properties act as mutually-exclusive parent references; the service
+# entities' own forms (application.update, compose.update, ...) keep their FK
+# fields editable (environmentId, githubId, ...).
+CHILD_ENTITIES = frozenset(
+    {
+        "domain",
+        "port",
+        "mount",
+        "backup",
+        "schedule",
+        "security",
+        "redirects",
+        "patch",
+        "previewDeployment",
+        "environment",
+    }
+)
+
 # String fields that are expected to hold multi-line content.
 MULTILINE_FIELDS = {
     "description",

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -872,22 +872,21 @@ class BrowserScreen(Screen):
         own = f"{entity_name}Id"
         return {field for field in props if field.endswith("Id") and field != own and field not in AMBIENT_ID_FIELDS}
 
-    def _form_parent_handling(self, action, entity_name: str, record: dict) -> tuple[set[str], dict]:
-        """Parent-id fields to hide from a child form, and the one to inject.
+    def _form_id_handling(self, action, entity_name: str, record: dict) -> tuple[set[str], dict]:
+        """Id fields to hide from a form, and the ones to inject.
 
-        Only when the current context carries a parent record; otherwise the
-        fields stay editable (current behavior).
+        Parent-id fields are hidden only with a parent context (and only for
+        curated child entities). The entity's own primary key is always hidden —
+        auto-generated on create, injected back from the record on update.
         """
-        if not self.current.record:
-            return set(), {}
-        candidates = self._parent_id_candidates(action, entity_name)
-        inject: dict = {}
-        for field in candidates:
-            value = record.get(field)
-            if value:
-                inject = {field: value}
-                break
-        return candidates, inject
+        excluded = set()
+        if self.current.record:
+            excluded |= self._parent_id_candidates(action, entity_name)
+        own = f"{entity_name}Id"
+        if own in action.request_schema.get("properties", {}):
+            excluded.add(own)
+        inject = {field: record[field] for field in excluded if record.get(field)}
+        return excluded, inject
 
     async def _open_form(self, action) -> None:
         """Open an action form.
@@ -914,7 +913,7 @@ class BrowserScreen(Screen):
                     enriched = await self._api_get(one_action, params)
                     if enriched:
                         record = enriched
-        excluded, inject = self._form_parent_handling(action, entity_name, record)
+        excluded, inject = self._form_id_handling(action, entity_name, record)
         self.app.push_screen(
             ActionFormScreen(
                 self.connection,

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -32,6 +32,7 @@ from dokli.tui.engine import (
     state_indicator,
 )
 from dokli.tui.engine.related import PARENT_ACTIONS, RELATED_ACTIONS
+from dokli.tui.engine.schemas import AMBIENT_ID_FIELDS
 from dokli.tui.engine.spec import PRIORITY_ENTITIES
 from dokli.tui.screens.generic.execute import confirm_and_run
 from dokli.tui.screens.generic.form import ActionFormScreen
@@ -856,19 +857,48 @@ class BrowserScreen(Screen):
             prefill["domainType"] = "compose"
         return prefill
 
+    def _parent_id_candidates(self, action, entity_name: str) -> set[str]:
+        """The parent-id fields of a child schema (foreign keys to a parent).
+
+        Every ``*Id`` property that is not the entity's own id nor an ambient
+        id is a mutually-exclusive parent reference.
+        """
+        props = set(action.request_schema.get("properties", {}))
+        own = f"{entity_name}Id"
+        return {field for field in props if field.endswith("Id") and field != own and field not in AMBIENT_ID_FIELDS}
+
+    def _form_parent_handling(self, action, entity_name: str, record: dict) -> tuple[set[str], dict]:
+        """Parent-id fields to hide from a child form, and the one to inject.
+
+        Only when the current context carries a parent record; otherwise the
+        fields stay editable (current behavior).
+        """
+        if not self.current.record:
+            return set(), {}
+        candidates = self._parent_id_candidates(action, entity_name)
+        inject: dict = {}
+        for field in candidates:
+            value = record.get(field)
+            if value:
+                inject = {field: value}
+                break
+        return candidates, inject
+
     async def _open_form(self, action) -> None:
         """Open an action form.
 
         Create actions start with the parent service id prefilled (when opened
         from a service's child category); update/save/edit actions are enriched
-        with the full record via ``one`` when available.
+        with the full record via ``one`` when available. Parent-id fields are
+        hidden from the form and injected from context.
         """
+        entity_name = self._selected_kind() or ""
         record: dict = {}
         if action.verb in ("create", "new"):
             record = self._create_prefill(action)
         else:
             record = self.selected or {}
-            entity = self.registry.get(self._selected_kind() or "")
+            entity = self.registry.get(entity_name)
             one_action = entity.get("one") if entity else None
             if entity is not None and one_action is not None:
                 params = {
@@ -879,12 +909,15 @@ class BrowserScreen(Screen):
                     enriched = await self._api_get(one_action, params)
                     if enriched:
                         record = enriched
+        excluded, inject = self._form_parent_handling(action, entity_name, record)
         self.app.push_screen(
             ActionFormScreen(
                 self.connection,
                 action,
                 record=record,
                 on_success=self._auto_deploy_callback(action),
+                excluded=excluded,
+                inject=inject,
                 classes="Entities",
             )
         )

--- a/dokli/tui/screens/generic/browser.py
+++ b/dokli/tui/screens/generic/browser.py
@@ -32,7 +32,7 @@ from dokli.tui.engine import (
     state_indicator,
 )
 from dokli.tui.engine.related import PARENT_ACTIONS, RELATED_ACTIONS
-from dokli.tui.engine.schemas import AMBIENT_ID_FIELDS
+from dokli.tui.engine.schemas import AMBIENT_ID_FIELDS, CHILD_ENTITIES
 from dokli.tui.engine.spec import PRIORITY_ENTITIES
 from dokli.tui.screens.generic.execute import confirm_and_run
 from dokli.tui.screens.generic.form import ActionFormScreen
@@ -192,9 +192,11 @@ class BrowserScreen(Screen):
 
     def _selected_kind(self) -> str | None:
         selected = self.selected
-        if not selected:
-            return None
-        return selected.get("_kind") or (self.current.kind if self.current.kind != "entities" else None)
+        kind = selected.get("_kind") if selected else None
+        if kind:
+            return kind
+        # Empty lists (e.g. a category with no records yet) still know their kind.
+        return self.current.kind if self.current.kind != "entities" else None
 
     async def _related_records(self, record: dict) -> list[dict]:
         """Related records of a selected record, cached by record identity."""
@@ -861,8 +863,11 @@ class BrowserScreen(Screen):
         """The parent-id fields of a child schema (foreign keys to a parent).
 
         Every ``*Id`` property that is not the entity's own id nor an ambient
-        id is a mutually-exclusive parent reference.
+        id is a mutually-exclusive parent reference — only for curated child
+        entities. Service entities' own forms keep their FK fields editable.
         """
+        if entity_name not in CHILD_ENTITIES:
+            return set()
         props = set(action.request_schema.get("properties", {}))
         own = f"{entity_name}Id"
         return {field for field in props if field.endswith("Id") and field != own and field not in AMBIENT_ID_FIELDS}

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -49,8 +49,9 @@ class ActionFormScreen(Screen):
         self.action = action
         self.record = record or {}
         self.on_success = on_success
+        self.excluded = excluded or set()
         self.inject = inject or {}
-        model = build_form_model(action.request_schema, name=f"{action.route}Form", excluded=excluded or set())
+        model = build_form_model(action.request_schema, name=f"{action.route}Form", excluded=self.excluded)
         prefill = {key: value for key, value in self.record.items() if key in model.model_fields}
         self.form = Form.from_model(model, data=prefill, classes="action-form")
 
@@ -107,7 +108,16 @@ class ActionFormScreen(Screen):
 
     def action_wizard(self) -> None:
         """Open the step-by-step wizard for the same action."""
-        self.app.push_screen(WizardScreen(self.connection, self.action, record=self.record, classes="Entities"))
+        self.app.push_screen(
+            WizardScreen(
+                self.connection,
+                self.action,
+                record=self.record,
+                excluded=self.excluded,
+                inject=self.inject,
+                classes="Entities",
+            )
+        )
 
     def action_cancel(self) -> None:
         """Cancel the form."""

--- a/dokli/tui/screens/generic/form.py
+++ b/dokli/tui/screens/generic/form.py
@@ -33,16 +33,24 @@ class ActionFormScreen(Screen):
         action: EntityAction,
         record: dict | None = None,
         on_success: Callable[[], None] | None = None,
+        excluded: set[str] | None = None,
+        inject: dict | None = None,
         *args,
         **kwargs,
     ) -> None:
-        """Construct the action form screen."""
+        """Construct the action form screen.
+
+        ``excluded`` fields are dropped from the form (e.g. parent-id fields);
+        ``inject`` fields are merged into the submitted body (e.g. the parent id
+        derived from context).
+        """
         super().__init__(*args, **kwargs)
         self.connection = connection
         self.action = action
         self.record = record or {}
         self.on_success = on_success
-        model = build_form_model(action.request_schema, name=f"{action.route}Form")
+        self.inject = inject or {}
+        model = build_form_model(action.request_schema, name=f"{action.route}Form", excluded=excluded or set())
         prefill = {key: value for key, value in self.record.items() if key in model.model_fields}
         self.form = Form.from_model(model, data=prefill, classes="action-form")
 
@@ -87,7 +95,7 @@ class ActionFormScreen(Screen):
             self,
             self.connection,
             self.action,
-            body,
+            {**self.inject, **body},
             on_success=self._success,
         )
 

--- a/dokli/tui/screens/generic/result.py
+++ b/dokli/tui/screens/generic/result.py
@@ -111,6 +111,8 @@ class ResultScreen(Screen):
             self._lines = _plain_lines(self.data)
             self._recompute_matches()
             await self._apply_search()
+            if not self._query:
+                self.query_one("#result-scroll", VerticalScroll).scroll_home(animate=False)
         except httpx.HTTPError as err:
             self.notify(f"API error: {err}", severity="error", timeout=10)
         finally:
@@ -171,16 +173,24 @@ class ResultScreen(Screen):
         self.run_worker(self._apply_search(), exclusive=True, group="search")  # type: ignore[arg-type]
 
     async def _apply_search(self) -> None:
-        """Render the result with the current matches highlighted."""
-        container = self.query_one("#result-scroll", VerticalScroll)
-        await container.remove_children()
+        """Render the result with the current matches highlighted.
+
+        A single persistent ``#result`` Label is updated in place — the scroll
+        container never re-mounts children, keeping its scrollbar stable.
+        """
+        self._recompute_matches()
+        label = self.query_one("#result", Label)
         if not self._query:
-            await container.mount(Label(_render_data(self.data), id="result"))
+            label.update(_render_data(self.data))
             self._render_status()
             return
-        widgets = [Label(self._highlight_line(line, i)) for i, line in enumerate(self._lines)]
-        await container.mount(*widgets)
-        self._scroll_to_current(container)
+        text = Text()
+        for i, line in enumerate(self._lines):
+            if i:
+                text.append("\n")
+            text.append(self._highlight_line(line, i))
+        label.update(text)
+        self._scroll_to_current()
         self._render_status()
 
     def _highlight_line(self, line: str, line_index: int) -> Text:
@@ -201,14 +211,13 @@ class ResultScreen(Screen):
             start = index + len(query)
         return text
 
-    def _scroll_to_current(self, container: VerticalScroll) -> None:
+    def _scroll_to_current(self) -> None:
         """Scroll the current match into view."""
         if not self._matches:
             return
+        container = self.query_one("#result-scroll", VerticalScroll)
         line_index = self._matches[self._match_index]
-        widgets = list(container.children)
-        if 0 <= line_index < len(widgets):
-            container.scroll_to_widget(widgets[line_index], animate=False)
+        container.scroll_to(y=line_index, animate=False)
 
     def _render_status(self) -> None:
         """Update the match counter label."""

--- a/dokli/tui/screens/generic/wizard.py
+++ b/dokli/tui/screens/generic/wizard.py
@@ -30,6 +30,8 @@ class WizardScreen(Screen):
         connection: ConnectionConfig,
         action: EntityAction,
         record: dict | None = None,
+        excluded: set[str] | None = None,
+        inject: dict | None = None,
         *args,
         **kwargs,
     ) -> None:
@@ -38,7 +40,8 @@ class WizardScreen(Screen):
         self.connection = connection
         self.action = action
         self.record = record or {}
-        self.model = build_form_model(action.request_schema, name=f"{action.route}Wizard")
+        self.inject = inject or {}
+        self.model = build_form_model(action.request_schema, name=f"{action.route}Wizard", excluded=excluded or set())
         self.fields = list(self.model.model_fields.items())
         self.controls = {
             name: FormControl.from_field(name, field, value=self.record.get(name)) for name, field in self.fields
@@ -111,6 +114,6 @@ class WizardScreen(Screen):
             self,
             self.connection,
             self.action,
-            body,
+            {**self.inject, **body},
             on_success=lambda: self.dismiss(None),
         )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -159,6 +159,25 @@ FAKE_SCHEMA = {
                 }
             }
         },
+        "/application.update": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "applicationId": {"type": "string"},
+                                    "environmentId": {"type": "string"},
+                                    "githubId": {"type": "string"},
+                                    "dockerImage": {"type": "string"},
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/deployment.all": {
             "get": {
                 "parameters": [
@@ -1809,7 +1828,7 @@ def test_create_form_prefills_parent(mocker):
             screen = app.screen
             screen.path = [
                 Level(
-                    kind="domains",
+                    kind="domain",
                     items=[],
                     entity="compose",
                     record={"composeId": "c1", "name": "torrents"},
@@ -1841,7 +1860,7 @@ def test_create_form_injects_parent_on_submit(mocker):
             screen = app.screen
             screen.path = [
                 Level(
-                    kind="domains",
+                    kind="domain",
                     items=[],
                     entity="compose",
                     record={"composeId": "c1", "name": "torrents"},
@@ -1936,6 +1955,39 @@ def test_category_picker_uses_child_entity(mocker):
             assert screen._selected_kind() == "domain"
             domain = registry.get("domain")
             assert any(a.route == "domain.create" for a, _ in screen._entity_bindings(domain))
+
+    _run(main())
+
+
+def test_service_update_form_keeps_fk_fields(mocker):
+    """We expect service entities' own update forms to keep FK fields editable
+    (environmentId, githubId) even with a parent context."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            screen = app.screen
+            screen.path = [
+                Level(
+                    kind="children",
+                    items=[{"_kind": "application", "applicationId": "a1", "name": "web"}],
+                    entity="application",
+                    record={"applicationId": "a1", "name": "web"},
+                )
+            ]
+            screen.current.index = 0
+            await pilot.pause()
+            entity = registry.get("application")
+            await screen._open_form(entity.get("update"))
+            await pilot.pause()
+            form_screen = app.screen
+            assert isinstance(form_screen, ActionFormScreen)
+            assert "environmentId" in form_screen.form.fields
+            assert "githubId" in form_screen.form.fields
+            assert form_screen.inject == {}
 
     _run(main())
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2053,6 +2053,34 @@ def test_child_update_form_hides_own_and_parent_ids(mocker):
     _run(main())
 
 
+def test_result_refresh_keeps_single_label(mocker):
+    """We expect re-rendering the result to update a single persistent label
+    (no remove/mount churn that would destabilize the scrollbar)."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+    action = registry.get("compose").get("readLogs")
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            screen = ResultScreen(_connection(), action, data="line1\nline2", params={})
+            app.install_screen(screen, name="result")
+            app.push_screen("result")
+            await pilot.pause()
+            screen._query = "line"
+            await screen._apply_search()
+            await pilot.pause()
+            container = screen.query_one("#result-scroll", VerticalScroll)
+            assert len(container.children) == 1
+            assert "line1" in str(screen.query_one("#result", Label).renderable)
+            screen._query = ""
+            await screen._apply_search()
+            await pilot.pause()
+            assert len(screen.query_one("#result-scroll", VerticalScroll).children) == 1
+
+    _run(main())
+
+
 async def _select_connection(app, pilot):
     list_view = app.screen.query_one("#connections-list")
     list_view.index = 0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -262,6 +262,7 @@ def _patch_api(mocker):
     client.request.side_effect = fake_request
     mocker.patch("dokli.tui.screens.generic.browser.APIClient", return_value=client)
     mocker.patch("dokli.tui.app.APIClient", return_value=client)
+    mocker.patch("dokli.tui.screens.generic.execute.APIClient", return_value=client)
     return responses
 
 
@@ -1796,7 +1797,8 @@ def test_mount_title_uses_path():
 
 
 def test_create_form_prefills_parent(mocker):
-    """We expect a create form opened from a service category to prefill the parent."""
+    """We expect a create form opened from a service category to hide parent-id
+    fields and prefill derived ones."""
     _patch_api(mocker)
     registry = parse_spec(FAKE_SCHEMA)
 
@@ -1819,10 +1821,68 @@ def test_create_form_prefills_parent(mocker):
             await pilot.pause()
             form_screen = app.screen
             assert isinstance(form_screen, ActionFormScreen)
-            assert form_screen.form.fields["composeId"].value == "c1"
+            assert "composeId" not in form_screen.form.fields
+            assert "applicationId" not in form_screen.form.fields
+            assert form_screen.inject == {"composeId": "c1"}
             assert str(form_screen.form.fields["domainType"].value) == "compose"
 
     _run(main())
+
+
+def test_create_form_injects_parent_on_submit(mocker):
+    """We expect the hidden parent id to be sent on submit."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            screen = app.screen
+            screen.path = [
+                Level(
+                    kind="domains",
+                    items=[],
+                    entity="compose",
+                    record={"composeId": "c1", "name": "torrents"},
+                )
+            ]
+            await pilot.pause()
+            domain = registry.get("domain")
+            await screen._open_form(domain.get("create"))
+            await pilot.pause()
+            form_screen = app.screen
+            form_screen.form.fields["host"].value = "x.example.com"
+            form_screen.action_submit()
+            await pilot.pause()
+            await pilot.press("y")
+            await asyncio.sleep(0.2)
+            await pilot.pause()
+            await pilot.pause()
+            calls = [c for c in screen.client.request.call_args_list if c[0][1] == "domain.create"]
+            assert calls
+            body = calls[-1][0][2].get("body", {})
+            assert body.get("composeId") == "c1"
+            assert body.get("host") == "x.example.com"
+
+    _run(main())
+
+
+def test_form_parent_ids_visible_without_context():
+    """We expect parent-id fields to stay editable when there is no parent context."""
+    from dokli.tui.engine.schemas import build_form_model
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "host": {"type": "string"},
+            "composeId": {"type": "string"},
+            "applicationId": {"type": "string"},
+        },
+    }
+    model = build_form_model(schema)
+    assert "composeId" in model.model_fields
+    assert "applicationId" in model.model_fields
 
 
 def test_empty_child_category_allows_create(mocker):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -159,6 +159,26 @@ FAKE_SCHEMA = {
                 }
             }
         },
+        "/domain.update": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "host": {"type": "string"},
+                                    "domainId": {"type": "string"},
+                                    "composeId": {"type": "string"},
+                                    "applicationId": {"type": "string"},
+                                },
+                                "required": ["host", "domainId"],
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/application.update": {
             "post": {
                 "requestBody": {
@@ -1987,7 +2007,48 @@ def test_service_update_form_keeps_fk_fields(mocker):
             assert isinstance(form_screen, ActionFormScreen)
             assert "environmentId" in form_screen.form.fields
             assert "githubId" in form_screen.form.fields
-            assert form_screen.inject == {}
+            assert "applicationId" not in form_screen.form.fields
+            assert form_screen.inject == {"applicationId": "a1"}
+
+    _run(main())
+
+
+def test_child_update_form_hides_own_and_parent_ids(mocker):
+    """We expect a child update form to hide its own primary key and the parent
+    id, injecting both from the record."""
+    _patch_api(mocker)
+    registry = parse_spec(FAKE_SCHEMA)
+
+    async def main():
+        app = DokliApp(config=_config())
+        async with app.run_test() as pilot:
+            await _mount_browser(app, pilot, _connection(), registry)
+            screen = app.screen
+            screen.path = [
+                Level(
+                    kind="domain",
+                    items=[
+                        {
+                            "_kind": "domain",
+                            "domainId": "d1",
+                            "host": "x.example.com",
+                            "composeId": "c1",
+                        }
+                    ],
+                    entity="compose",
+                    record={"composeId": "c1", "name": "torrents"},
+                )
+            ]
+            screen.current.index = 0
+            await pilot.pause()
+            domain = registry.get("domain")
+            await screen._open_form(domain.get("update"))
+            await pilot.pause()
+            form_screen = app.screen
+            assert isinstance(form_screen, ActionFormScreen)
+            assert "domainId" not in form_screen.form.fields
+            assert "composeId" not in form_screen.form.fields
+            assert form_screen.inject == {"domainId": "d1", "composeId": "c1"}
 
     _run(main())
 

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "dokli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #69: hide mutually-exclusive parent-id fields from child forms.

## What
- Child schemas carry several parent-id fields (`applicationId`, `composeId`,
  `previewDeploymentId`, ...); the form rendered all of them editable, so a user
  could set the wrong one or both. Now they are **hidden from the form** and the
  applicable one is **injected from context** on submit.
- `build_form_model` gained an `excluded` arg; `ActionFormScreen` accepts
  `excluded` + `inject` and merges `inject` into the submitted body.
- `_parent_id_candidates`: any `*Id` property that is not the entity's own id
  nor an ambient id (`AMBIENT_ID_FIELDS`: serverId, destinationId, registryId,
  ...) is treated as a parent reference.
- `_form_parent_handling`: when the current context has a parent record, the
  candidates are hidden and the one present on the record/prefill is injected
  (e.g. a domain under a compose sends only `composeId`); without a parent
  context the fields stay editable (current behavior).

## Verified
- 262 tests; `make lint` clean.
- Tests: parent-id fields hidden from a compose-domain create form; the hidden
  `composeId` is sent on submit; fields stay visible without parent context.
- README not needed (internal safety).
